### PR TITLE
Fix setting None/Static fog to 0 causing broken rendering

### DIFF
--- a/src/main/resources/rs117/hd/vert.glsl
+++ b/src/main/resources/rs117/hd/vert.glsl
@@ -126,4 +126,9 @@ void main() {
         // Combine distance fog with edge fog
         vFogAmount = max(distanceFogAmount, edgeFogAmount);
     }
+    else
+    {
+        // Set out parameter as it is initialized to garbage data otherwise
+        vFogAmount = 0.0f;
+    }
 }


### PR DESCRIPTION
Fixes #5.

The problem is due to an uninitialised out parameter in `vert.glsl` when `fogDepth <= 0`. A simple else = 0 fixes the issue.