### PR TITLE
Github issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report.md
@@ -1,0 +1,32 @@
+---
+name: "\U0001F41B Bug report"
+about: Create a report to help us improve
+
+---
+
+Please check if your issue is not a duplicate by [searching existing issues](https://github.com/RS117/RLHD/search?type=Issues)
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Environment (please complete the following information):**
+ - OS: [e.g. Windows, Ubuntu, macOS]
+ - RuneLite version: [e.g 1.4.6]
+ - Launcher version: [e.g 1.5.2]
+
+**Additional context**
+Add any other context about the problem here, e.g. logs. Your client logs can usually be found in
+`C:\Users\<your_user_name>\.runelite\logs` on Windows and `~/.runelite/logs` on Linux and macOS.

--- a/.github/ISSUE_TEMPLATE/Feature_request.md
+++ b/.github/ISSUE_TEMPLATE/Feature_request.md
@@ -1,0 +1,19 @@
+---
+name: "\U0001F680  Feature Request"
+about: Suggest an idea for this project
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always
+frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've
+considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.


### PR DESCRIPTION
Due to the massive amounts of issues and feature requests coming in at the moment, it might be wise to use Runelite its issue templates. This pre-fills an issue with guidelines on how to report one properly.