### PR TITLE
New brightness config

### DIFF
--- a/src/main/java/rs117/hd/HdPlugin.java
+++ b/src/main/java/rs117/hd/HdPlugin.java
@@ -191,7 +191,10 @@ public class HdPlugin extends Plugin implements DrawCallbacks
 
 	@Inject
 	private ProceduralGenerator proceduralGenerator;
-	
+
+	@Inject
+	private ConfigManager configManager;
+
 	enum ComputeMode
 	{
 		OPENGL,
@@ -407,6 +410,8 @@ public class HdPlugin extends Plugin implements DrawCallbacks
 	@Override
 	protected void startUp()
 	{
+		convertOldBrightnessConfig();
+
 		configGroundTextures = config.groundTextures();
 		configWaterEffects = config.waterEffects();
 		configLevelOfDetail = config.levelOfDetail();
@@ -1726,7 +1731,7 @@ public class HdPlugin extends Plugin implements DrawCallbacks
 
 			// get ambient light strength from either the config or the current area
 			float ambientStrength = environmentManager.currentAmbientStrength;
-			ambientStrength *= config.brightness().getAmount();
+			ambientStrength *= (double)config.brightness() / 20;
 			gl.glUniform1f(uniAmbientStrength, ambientStrength);
 
 			// and ambient color
@@ -1735,7 +1740,7 @@ public class HdPlugin extends Plugin implements DrawCallbacks
 
 			// get light light strength from either the config or the current area
 			float lightStrength = environmentManager.currentDirectionalStrength;
-			lightStrength *= config.brightness().getAmount();
+			lightStrength *= (double)config.brightness() / 20;
 			gl.glUniform1f(uniLightStrength, lightStrength);
 
 			// and light color
@@ -2446,6 +2451,35 @@ public class HdPlugin extends Plugin implements DrawCallbacks
 		else if (data != null)
 		{
 			gl.glBufferSubData(target, 0, size, data);
+		}
+	}
+
+	//Sets the new brightness setting from the old brightness setting.
+	//This can be removed later on when most people have updated the plugin
+	private void convertOldBrightnessConfig()
+	{
+		try
+		{
+			String oldBrightnessValue = configManager.getConfiguration("hd", "brightness");
+
+			if (!oldBrightnessValue.equals("set"))
+			{
+				String[][] newBrightnessValues = {{"LOWEST", "10"}, {"LOWER", "15"}, {"DEFAULT", "20"}, {"HIGHER", "25"}, {"HIGHEST", "30"}};
+				for (String[] newValue : newBrightnessValues)
+				{
+					if (newValue[0].equals(oldBrightnessValue))
+					{
+						configManager.setConfiguration("hd", "brightness2", newValue[1]);
+						break;
+					}
+				}
+
+				configManager.setConfiguration("hd", "brightness", "set");
+			}
+		}
+		catch (Exception e)
+		{
+			//Happens if people don't have the old brightness setting, then it doesn't need converting anyway.
 		}
 	}
 

--- a/src/main/java/rs117/hd/HdPluginConfig.java
+++ b/src/main/java/rs117/hd/HdPluginConfig.java
@@ -35,7 +35,6 @@ import static rs117.hd.HdPlugin.MAX_FOG_DEPTH;
 import rs117.hd.config.AntiAliasingMode;
 import rs117.hd.config.ColorBlindMode;
 import rs117.hd.config.Contrast;
-import rs117.hd.config.Brightness;
 import rs117.hd.config.LevelOfDetail;
 import rs117.hd.config.MaxDynamicLights;
 import rs117.hd.config.Saturation;
@@ -162,17 +161,18 @@ public interface HdPluginConfig extends Config
 		return Contrast.DEFAULT;
 	}
 
+	@Range(
+		min = 1,
+		max = 50
+	)
 	@ConfigItem(
-		keyName = "brightness",
+		keyName = "brightness2",
 		name = "Brightness",
 		description = "Controls the brightness of scene lighting.",
 		position = 9,
 		section = generalSettings
 	)
-	default Brightness brightness()
-	{
-		return Brightness.DEFAULT;
-	}
+	default int brightness() { return 20; }
 
 	@ConfigItem(
 		keyName = "levelOfDetail",


### PR DESCRIPTION
this adds a Range config to the brightness setting. So people can change the brightness better as theres 49 different values between 1 and 50. It sets the brightness value by dividing the int value with 20 so its between 0.05 and 2.5 and changing it by one changes the brightness by 0.05. Previously the lowest was 0.5 and highest was 1.5 so people can now put it alot lower which can be cool to see the lighting better and higher to see better in caves and  stuff. #83

Also it converts the old brightness setting to the new one so the brightness config wont reset after updating. I also tested this alot and it all works fine.