### PR TITLE
Added gpu info logging on startup for debugging purposes.

### DIFF
--- a/src/main/java/rs117/hd/HdPlugin.java
+++ b/src/main/java/rs117/hd/HdPlugin.java
@@ -453,6 +453,18 @@ public class HdPlugin extends Plugin implements DrawCallbacks
 
 				invokeOnMainThread(() ->
 				{
+					GLDrawable dummyDrawable = GLDrawableFactory.getFactory(GLProfile.getDefault())
+							.createDummyDrawable(GLProfile.getDefaultDevice(), true, new GLCapabilities(GLProfile.getDefault()), null);
+					dummyDrawable.setRealized(true);
+					GLContext versionContext = dummyDrawable.createContext(null);
+					versionContext.makeCurrent();
+					GL versionGL = versionContext.getGL().getGL(); 
+
+					log.info("GPU manufacturer: {}", versionGL.glGetString(GL.GL_VENDOR));
+					log.info("GPU device: {}", versionGL.glGetString(GL.GL_RENDERER));
+					log.info("GPU driver: {}", versionGL.glGetString(GL.GL_VERSION));
+					versionContext.destroy();
+
 					GLProfile glProfile = GLProfile.get(GLProfile.GL4);
 
 					GLCapabilities glCaps = new GLCapabilities(glProfile);


### PR DESCRIPTION
Adds three lines of GPU information to the log. Useful for debugging purposes.

![example](https://i.gyazo.com/b23db37d8606909f7f7fce47e6794869.png)