### PR TITLE
gpu: display device and driver being used during plugin startup

### DIFF
--- a/src/main/java/rs117/hd/HdPlugin.java
+++ b/src/main/java/rs117/hd/HdPlugin.java
@@ -453,6 +453,19 @@ public class HdPlugin extends Plugin implements DrawCallbacks
 
 				invokeOnMainThread(() ->
 				{
+					// Get and display the device and driver used by the GPU plugin
+					GLDrawable dummyDrawable = GLDrawableFactory.getFactory(GLProfile.getDefault())
+						.createDummyDrawable(GLProfile.getDefaultDevice(), true, new GLCapabilities(GLProfile.getDefault()), null);
+					dummyDrawable.setRealized(true);
+					GLContext versionContext = dummyDrawable.createContext(null);
+					versionContext.makeCurrent();
+					// Due to probable JOGL spaghetti, calling .getGL() once results in versionGL being set to null
+					// I have no idea exactly why the second call works, but it results in the correct GL being gotten.
+					GL versionGL = versionContext.getGL().getGL();
+					log.info("Using device: {}", versionGL.glGetString(GL.GL_RENDERER));
+					log.info("Using driver: {}", versionGL.glGetString(GL.GL_VERSION));
+					versionContext.destroy();
+
 					GLProfile glProfile = GLProfile.get(GLProfile.GL4);
 
 					GLCapabilities glCaps = new GLCapabilities(glProfile);


### PR DESCRIPTION
Closes #100 

A while back, I made runelite/runelite#13795 for the core GPU plugin, to help let people know if their attempts at telling their computer to use the correct GPU was successful. It has come to my attention that it would also be useful in this project, even more so given the extra requirements HD has. It has also been tested on multiple different systems with multiple different combinations of dGPU and iGPU, and hasn't affected the loading of the plugin (those that couldn't before would still fail at the same place, which is after this modification)