### PR TITLE
Added functionality to allow "Impostor" objects to have lights, and added lights to various Imposter objects.

### DIFF
--- a/src/main/java/rs117/hd/HdPlugin.java
+++ b/src/main/java/rs117/hd/HdPlugin.java
@@ -64,41 +64,8 @@ import jogamp.nativewindow.jawt.x11.X11JAWTWindow;
 import jogamp.nativewindow.macosx.OSXUtil;
 import jogamp.newt.awt.NewtFactoryAWT;
 import lombok.extern.slf4j.Slf4j;
-import net.runelite.api.BufferProvider;
-import net.runelite.api.Client;
-import net.runelite.api.Constants;
-import net.runelite.api.DecorativeObject;
-import net.runelite.api.GameObject;
-import net.runelite.api.GameState;
-import net.runelite.api.GroundObject;
-import net.runelite.api.Model;
-import net.runelite.api.NodeCache;
-import net.runelite.api.Perspective;
-import net.runelite.api.Renderable;
-import net.runelite.api.Scene;
-import net.runelite.api.SceneTileModel;
-import net.runelite.api.SceneTilePaint;
-import net.runelite.api.Texture;
-import net.runelite.api.TextureProvider;
-import net.runelite.api.Tile;
-import net.runelite.api.WallObject;
-import net.runelite.api.events.DecorativeObjectChanged;
-import net.runelite.api.events.DecorativeObjectDespawned;
-import net.runelite.api.events.DecorativeObjectSpawned;
-import net.runelite.api.events.GameObjectChanged;
-import net.runelite.api.events.GameObjectDespawned;
-import net.runelite.api.events.GameObjectSpawned;
-import net.runelite.api.events.GameStateChanged;
-import net.runelite.api.events.GroundObjectChanged;
-import net.runelite.api.events.GroundObjectDespawned;
-import net.runelite.api.events.GroundObjectSpawned;
-import net.runelite.api.events.NpcChanged;
-import net.runelite.api.events.NpcDespawned;
-import net.runelite.api.events.NpcSpawned;
-import net.runelite.api.events.ProjectileMoved;
-import net.runelite.api.events.WallObjectChanged;
-import net.runelite.api.events.WallObjectDespawned;
-import net.runelite.api.events.WallObjectSpawned;
+import net.runelite.api.*;
+import net.runelite.api.events.*;
 import net.runelite.api.hooks.DrawCallbacks;
 import net.runelite.client.callback.ClientThread;
 import net.runelite.client.config.ConfigManager;
@@ -161,7 +128,7 @@ public class HdPlugin extends Plugin implements DrawCallbacks
 
 	@Inject
 	private Client client;
-	
+
 	@Inject
 	private OpenCLManager openCLManager;
 
@@ -2532,6 +2499,12 @@ public class HdPlugin extends Plugin implements DrawCallbacks
 		GameObject gameObject = gameObjectSpawned.getGameObject();
 		lightManager.addObjectLight(gameObject, gameObjectSpawned.getTile().getRenderLevel(), gameObject.sizeX(), gameObject.sizeY(), gameObject.getOrientation().getAngle());
 	}
+
+    @Subscribe
+    public void  onVarbitChanged(VarbitChanged varbitChanged)
+    {
+        lightManager.updateImpostorObjectLights(varbitChanged);
+    }
 
 	@Subscribe
 	public void onGameObjectChanged(GameObjectChanged gameObjectChanged)

--- a/src/main/java/rs117/hd/lighting/LightManager.java
+++ b/src/main/java/rs117/hd/lighting/LightManager.java
@@ -31,34 +31,25 @@ import java.awt.Color;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.Iterator;
-import java.util.List;
+import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Stream;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import lombok.extern.slf4j.Slf4j;
-import net.runelite.api.Client;
-import net.runelite.api.Constants;
-import net.runelite.api.DecorativeObject;
-import net.runelite.api.GameObject;
-import net.runelite.api.GameState;
-import net.runelite.api.GroundObject;
-import net.runelite.api.NPC;
-import net.runelite.api.Perspective;
-import net.runelite.api.Projectile;
-import net.runelite.api.Tile;
-import net.runelite.api.TileObject;
-import net.runelite.api.WallObject;
+import net.runelite.api.*;
 import net.runelite.api.coords.LocalPoint;
 import net.runelite.api.coords.WorldPoint;
 import net.runelite.api.events.NpcDespawned;
 import net.runelite.api.events.NpcChanged;
+import net.runelite.api.events.VarbitChanged;
 import rs117.hd.HdPlugin;
 import rs117.hd.HdPluginConfig;
 import rs117.hd.HDUtils;
+
+import static net.runelite.api.NullObjectID.NULL_33336;
+import static net.runelite.api.ObjectID.FIRE_OF_ETERNAL_LIGHT;
 
 @Singleton
 @Slf4j
@@ -76,6 +67,7 @@ public class LightManager
 	ArrayList<Light> allLights = new ArrayList<>();
 	ArrayList<Light> sceneLights = new ArrayList<>();
 	ArrayList<Projectile> sceneProjectiles = new ArrayList<>();
+    Map<ObjectLight, Light> impostorObjectLights = new HashMap<>();
 
 	long lastFrameTime = -1;
 
@@ -634,7 +626,7 @@ public class LightManager
 	{
 		int id = tileObject.getId();
 		ObjectLight objectLight = ObjectLight.find(id);
-		if (objectLight == null)
+		if (objectLight == null || impostorObjectLights.containsKey(objectLight))
 		{
 			return;
 		}
@@ -715,6 +707,19 @@ public class LightManager
 		light.z = (int) tileHeight - light.height - 1;
 		light.object = tileObject;
 
+        try {
+            // If this objectLight is an impostor, check that the current object definition impostor has the same ID
+            if (objectLight.isImposter() &&
+                    objectLight.getImposterId() != client.getObjectDefinition(tileObject.getId()).getImpostor().getId()) {
+                impostorObjectLights.put(objectLight, light);
+                return;
+            }
+        } catch (NullPointerException ex) {
+            // Null pointer is thrown on ObjectDefinition#getImpostor if it isn't a multiloc / doesn't have impostors
+            // This should only occur if the ObjectLight was defined as an impostor when it isn't
+            return;
+        }
+
 		sceneLights.add(light);
 	}
 
@@ -727,11 +732,41 @@ public class LightManager
 			return;
 		}
 
+        if (impostorObjectLights.remove(objectLight) != null) {
+            return;
+        }
+
 		LocalPoint localLocation = tileObject.getLocalLocation();
 		int plane = tileObject.getWorldLocation().getPlane();
 
 		sceneLights.removeIf(light -> light.x == localLocation.getX() && light.y == localLocation.getY() && light.plane == plane);
 	}
+
+    public void updateImpostorObjectLights(VarbitChanged varbit) {
+        if (impostorObjectLights.isEmpty()) {
+            return;
+        }
+
+        for(Iterator<Map.Entry<ObjectLight, Light>> it = impostorObjectLights.entrySet().iterator(); it.hasNext();) {
+            Map.Entry<ObjectLight, Light> entry = it.next();
+
+            // Don't bother checking the impostor, if the varbit controlling this object didn't update
+            if (varbit.getIndex() != entry.getKey().getVarp()) {
+                continue;
+            }
+
+            try {
+                if (entry.getKey().getImposterId() == client.getObjectDefinition(entry.getKey().getId()[0]).getImpostor().getId()) {
+                    sceneLights.add(entry.getValue());
+                    it.remove();
+                }
+            } catch (NullPointerException ex) {
+                // object wasn't an imposter
+                log.debug("ObjectLight was not imposter : {}", entry.getKey().name());
+                it.remove();
+            }
+        }
+    }
 
 	int tileObjectHash(TileObject tileObject)
 	{

--- a/src/main/java/rs117/hd/lighting/LightManager.java
+++ b/src/main/java/rs117/hd/lighting/LightManager.java
@@ -753,9 +753,15 @@ public class LightManager
                     try {
                         // Check if it's the Impostor we want
                         if (entry.getKey().getImposterId() == client.getObjectDefinition(entry.getKey().getId()[0]).getImpostor().getId()) {
+                            Light toAdd = entry.getValue();
+                            if (sceneLights.stream().anyMatch(light -> light.object != null && tileObjectHash(light.object) == tileObjectHash(toAdd.object)))
+                            {
+                                // prevent duplicate lights being spawned for the same Impostor
+                                return;
+                            }
                             sceneLights.add(entry.getValue());
                         } else {
-                            // If it isn't, try to remove the Light from the scene if it has been there before
+                            // If it isn't the Impostor we want, try to remove the Light from the scene if it has been there before
                             Light toRemove = entry.getValue();
                             sceneLights.removeIf(light -> light.x == toRemove.x && light.y == toRemove.y && light.plane == toRemove.plane);
                         }

--- a/src/main/java/rs117/hd/lighting/ObjectLight.java
+++ b/src/main/java/rs117/hd/lighting/ObjectLight.java
@@ -29,9 +29,10 @@ import com.google.common.collect.ImmutableMap;
 import java.util.Map;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import static net.runelite.api.NullObjectID.NULL_5208;
-import static net.runelite.api.NullObjectID.NULL_5247;
 import net.runelite.api.ObjectID;
+import net.runelite.api.Varbits;
+
+import static net.runelite.api.NullObjectID.*;
 import static net.runelite.api.ObjectID.*;
 import static rs117.hd.lighting.LightManager.Alignment;
 import static rs117.hd.lighting.LightManager.LightType;
@@ -191,6 +192,20 @@ enum ObjectLight
 
 	// Trollheim
 	EADGAR_CAVE_EXIT(70, Alignment.CENTER, 250, 6f, rgb(255, 255, 255), LightType.STATIC, 0, 0, CAVE_EXIT_3760),
+
+    // My Arm Fire Pits
+    /* https://chisel.weirdgloop.org/varbs/display?varbit=6528#object33334Title */
+    FIRE_OF_NOURISHMENT(50, Alignment.CENTER, 500, 3f, rgb(11, 252, 3), LightType.FLICKER, 0, 4, ObjectID.FIRE_OF_NOURISHMENT, true, 1785, NULL_33334),
+    /* https://chisel.weirdgloop.org/varbs/display?varbit=6531 */
+    FIRE_OF_UNSEASONAL_WARMTH(50, Alignment.CENTER, 750, 2.5f, rgb(255, 85, 0), LightType.FLICKER, 0, 4, ObjectID.FIRE_OF_UNSEASONAL_WARMTH, true, 1785, NULL_33335),
+    /* https://chisel.weirdgloop.org/varbs/display?varbit=6532 */
+    FIRE_PIT_GIANT_MOLE(50, Alignment.CENTER, 1500, 1.5f, rgb(214, 203, 199), LightType.PULSE, 750, 4, ObjectID.FIRE_OF_ETERNAL_LIGHT, true, 1785, NULL_33336),
+    /* https://chisel.weirdgloop.org/varbs/display?varbit=6533 */
+    FIRE_PIT_LUMBRIDGE_SWAMP(50, Alignment.CENTER, 1500, 1.5f, rgb(214, 203, 199), LightType.PULSE, 750, 4, ObjectID.FIRE_OF_ETERNAL_LIGHT, true, 1785, NULL_33337),
+    /* https://chisel.weirdgloop.org/varbs/display?varbit=6534 */
+    FIRE_PIT_MOS_LE_HARMLESS(50, Alignment.CENTER, 1500, 1.5f, rgb(214, 203, 199), LightType.PULSE, 750, 4, ObjectID.FIRE_OF_ETERNAL_LIGHT, true, 1785, NULL_33338),
+    /* https://chisel.weirdgloop.org/varbs/display?varbit=6535 */
+    FIRE_OF_DEHUMIDIFICATION(50, Alignment.CENTER, 750, 4f, rgb(219, 252, 3), LightType.FLICKER, 0, 6, ObjectID.FIRE_OF_DEHUMIDIFICATION, true, 1785, NULL_33339),
 
 	// Underground Pass
 	WELL_OF_VOYAGE(200, Alignment.CENTER, 250, 6f, rgb(255, 255, 255), LightType.PULSE, 1200, 30, WELL_4004, WELL_4005),
@@ -375,6 +390,15 @@ enum ObjectLight
 	private final float duration;
 	private final float range;
 
+    // Is this object an imposter
+    private boolean imposter = false;
+    private int imposterId = -1;
+    // If so, what varp is it's status dependant on
+    // (You can get varp from the varbit : either search dump.varbit for "varbit_#" and "basevar" is the varp
+    // or run client#getVarbit#getIndex to get the varp
+    // https://gitlab.com/waliedyassen/cache-dumps/-/raw/master/dump.varbit
+    private int varp = -1;
+
 	ObjectLight(int height, Alignment alignment, int size, float strength, int rgb, LightType lightType, float duration, float range, int... ids)
 	{
 		this.height = height;
@@ -387,6 +411,15 @@ enum ObjectLight
 		this.range = range;
 		this.id = ids;
 	}
+
+    // Constructor for imposters
+    ObjectLight(int height, Alignment alignment, int size, float strength, int rgb, LightType lightType, float duration, float range, int id, boolean imposter, int varp, int parentId)
+    {
+        this(height, alignment, size, strength, rgb, lightType, duration, range, parentId);
+        this.imposter = imposter;
+        this.imposterId = id;
+        this.varp = varp;
+    }
 
 	private static final Map<Integer, ObjectLight> LIGHTS;
 

--- a/src/main/java/rs117/hd/lighting/ObjectLight.java
+++ b/src/main/java/rs117/hd/lighting/ObjectLight.java
@@ -335,6 +335,7 @@ enum ObjectLight
 	CEILING_LIGHT(0, Alignment.CENTER, 800, 3f, rgb(255, 255, 255), LightType.FLICKER, 0, 10, 20868),
 	// Hallowed Sepulchre
 	HALLOWED_SEPULCHRE_MAGICAL_OBELISK(300, Alignment.CENTER, 500, 4f, rgb(255, 204, 0), LightType.PULSE, 2100, 20, MAGICAL_OBELISK),
+    HALLOWED_PORTAL_FRAME(200, Alignment.CENTER, 1000, 4f, rgb(0, 0, 255), LightType.PULSE, 1000, 10, PORTAL_38829, true, 2730, NULL_39533),
 	SARADOMIN_BRAZIER(200, Alignment.CENTER, 500, 4f, rgb(0, 0, 255), LightType.FLICKER, 0, 20, 39525, 39526),
 	// Darkmeyer
 	RED_STREET_LAMP(250, Alignment.CENTER, 300, 3f, rgb(255, 0, 0), LightType.FLICKER, 0, 20, LAMP_39152),


### PR DESCRIPTION
We can now add lighting to Impostor objects. Added an additional parameter constructor for "ObjectLight" which takes in the "ParentId" of the Object that is the "parent: to the Impostor we want to add light to, as well as the varp that controls which Impostor is showing so we can check for updates.

Used this to add lighting effects to the "Making Friends with My Arm" fire pits.

Reasoning behind the chosen Light values for the fire pits : 
- FIRE_OF_ETERNAL_LIGHT
    - Decided to go with a large, weak(er) slow pulse for these lights, because they are meant to "light" the entire underground area they are in, I thought it made sense to give them a more subtle pulse effect and larger radius.
- The other pits I went with a flicker and a smaller size as it fits better (they aren't "lighting" and entire area, so more localized light emission seemed to make sense)

Testing : Tested locally, both on an account with the fire pits built and without. Also built a fire pit and confirmed lighting was added as soon as the Impostor changed.