### PR TITLE
Add support URL

### DIFF
--- a/runelite-plugin.properties
+++ b/runelite-plugin.properties
@@ -1,5 +1,6 @@
 displayName=117 HD (beta)
 author=117
+support=https://github.com/RS117/RLHD
 description=GPU renderer with a suite of graphical enhancements
 tags=hd,high,detail,graphics,shaders,textures
 plugins=rs117.hd.HdPlugin


### PR DESCRIPTION
Adds the repo URL. Without the field, clicking Support takes you to the [latest commit (at time of submitting)](https://github.com/RS117/RLHD/tree/58772d5fc057c04b06eb6377ed85a70215153e32) instead of the [master page](https://github.com/RS117/RLHD).  