### PR TITLE
Remove getCachedModels2: no longer part of the client API

### DIFF
--- a/src/main/java/rs117/hd/HdPlugin.java
+++ b/src/main/java/rs117/hd/HdPlugin.java
@@ -72,7 +72,6 @@ import net.runelite.api.GameObject;
 import net.runelite.api.GameState;
 import net.runelite.api.GroundObject;
 import net.runelite.api.Model;
-import net.runelite.api.NodeCache;
 import net.runelite.api.Perspective;
 import net.runelite.api.Renderable;
 import net.runelite.api.Scene;
@@ -555,11 +554,6 @@ public class HdPlugin extends Plugin implements DrawCallbacks
 				textureArrayId = -1;
 				textureHDArrayId = -1;
 
-				// increase size of model cache for dynamic objects since we are extending scene size
-				NodeCache cachedModels2 = client.getCachedModels2();
-				cachedModels2.setCapacity(256);
-				cachedModels2.setRemainingCapacity(256);
-				cachedModels2.reset();
 
 				// load all dynamic scene lights from text file
 				lightManager.loadLightsFromFile();


### PR DESCRIPTION
This change lines up with the recent API change made by Adam here: https://github.com/runelite/runelite/commit/4cab29cf2f3f1e969dfa13705baa52d4ee80ff38