### PR TITLE
optimize animated model pipeline

### DIFF
--- a/src/main/java/rs117/hd/GpuFloatBuffer.java
+++ b/src/main/java/rs117/hd/GpuFloatBuffer.java
@@ -37,6 +37,10 @@ class GpuFloatBuffer
 		buffer.put(texture).put(u).put(v).put(pad);
 	}
 
+	void put(float[] floats) {
+		buffer.put(floats);
+	}
+
 	void flip()
 	{
 		buffer.flip();

--- a/src/main/java/rs117/hd/GpuIntBuffer.java
+++ b/src/main/java/rs117/hd/GpuIntBuffer.java
@@ -42,6 +42,10 @@ class GpuIntBuffer
 		buffer.put(x).put(y).put(z).put(c);
 	}
 
+	void put(int[] ints) {
+		buffer.put(ints);
+	}
+
 	void flip()
 	{
 		buffer.flip();

--- a/src/main/java/rs117/hd/materials/Material.java
+++ b/src/main/java/rs117/hd/materials/Material.java
@@ -24,7 +24,9 @@
  */
 package rs117.hd.materials;
 
+import java.util.Arrays;
 import java.util.HashMap;
+
 import lombok.Getter;
 
 @Getter
@@ -338,16 +340,27 @@ public enum Material
 	}
 
 	private static final HashMap<Integer, Material> DIFFUSE_ID_MATERIAL_MAP;
+	private static final int[] MATERIAL_DIFUSE_INDEX_MAP;
 
 	static
 	{
 		DIFFUSE_ID_MATERIAL_MAP = new HashMap<>();
+		MATERIAL_DIFUSE_INDEX_MAP = new int[10000];
+		Arrays.fill(MATERIAL_DIFUSE_INDEX_MAP, 0);
+
+		int index = 0;
 		for (Material material : values())
 		{
 			if (!DIFFUSE_ID_MATERIAL_MAP.containsKey(material.diffuseMapId))
 			{
 				DIFFUSE_ID_MATERIAL_MAP.put(material.diffuseMapId, material);
+
+				if (material.diffuseMapId > 0 && material.diffuseMapId < 9999) {
+					MATERIAL_DIFUSE_INDEX_MAP[material.diffuseMapId] = index;
+				}
 			}
+
+			index++;
 		}
 	}
 
@@ -361,6 +374,7 @@ public enum Material
 	static
 	{
 		MATERIAL_INDEX_MAP = new HashMap<>();
+
 		int index = 0;
 		for (Material material : values())
 		{
@@ -372,6 +386,14 @@ public enum Material
 	public static int getIndex(Material material)
 	{
 		return MATERIAL_INDEX_MAP.getOrDefault(material, 0);
+	}
+
+	public static int getIndexFromDiffuseID(int id) {
+		if (id < 0 || id > 9999) {
+			return 0;
+		}
+
+		return MATERIAL_DIFUSE_INDEX_MAP[id];
 	}
 
 	public static Material[] getAllTextures()


### PR DESCRIPTION
This mainly optimizes the performance of `SceneUploader.pushFace` which gets called a ton when there are many animated models on screen.

The main changes are:
* bulk buffer writes by exposing the underlying buffer's bulk methods
* simplifying material index lookup

The material index lookup was quite slow even with a hashmap just due the volume of calls. I simplified it to a primitive mapping of ints to ints but I would appreciate if somebody could check my assertions. 

I assumed that the `diffuseMapId` would never be greater than 10,000 or less than zero.

It is less than zero once for the `NONE` material but that case is handled correctly.

My framerate went from ~48 FPS before the patch to ~60FPS (capped) while standing in area with a lot NPCs. 