### PR TITLE
Optimize MacOS Intel workaround

### DIFF
--- a/src/main/java/rs117/hd/HdPlugin.java
+++ b/src/main/java/rs117/hd/HdPlugin.java
@@ -150,7 +150,7 @@ public class HdPlugin extends Plugin implements DrawCallbacks
 	static final int MAX_DISTANCE = 90;
 	static final int MAX_FOG_DEPTH = 100;
 	// MAX_MATERIALS and MAX_LIGHTS must match the #defined values in the HD and shadow fragment shaders
-	private static final int MAX_MATERIALS = 200;
+	private static final int MAX_MATERIALS = Material.values().length;
 	private static final int MAX_LIGHTS = 100;
 	private static final int MATERIAL_PROPERTIES_COUNT = 12;
 	private static final int LIGHT_PROPERTIES_COUNT = 8;
@@ -685,6 +685,19 @@ public class HdPlugin extends Plugin implements DrawCallbacks
 		return configManager.getConfig(HdPluginConfig.class);
 	}
 
+	private String generateFetchMaterialCases(int from, int to)
+	{
+		int length = to - from;
+		if (length == 1)
+		{
+			return "material[" + from + "]";
+		}
+		int middle = from + length / 2;
+		return "i < " + middle +
+			" ? " + generateFetchMaterialCases(from, middle) +
+			" : " + generateFetchMaterialCases(middle, to);
+	}
+
 	private void initProgram() throws ShaderException
 	{
 		String versionHeader = OSType.getOSType() == OSType.Linux ? LINUX_VERSION_HEADER : WINDOWS_VERSION_HEADER;
@@ -695,18 +708,12 @@ public class HdPlugin extends Plugin implements DrawCallbacks
 			{
 				case "version_header":
 					return versionHeader;
+				case "MAX_MATERIALS":
+					return String.format("#define %s %d\n", key, MAX_MATERIALS);
 				case "CONST_MACOS_INTEL_WORKAROUND":
 					return String.format("#define %s %d\n", key, config.macosIntelWorkaround() ? 1 : 0);
-				case "MACOS_INTEL_WORKAROUND_MATERIAL_CASES": {
-					StringBuilder sb = new StringBuilder(MAX_MATERIALS * (
-						"case : return material[];".length() +
-						((int) Math.log10(MAX_MATERIALS) + 1) * 2));
-					for (int i = 0; i < MAX_MATERIALS; i++)
-					{
-						sb.append("case ").append(i).append(": return material[").append(i).append("];\n");
-					}
-					return sb.toString();
-				}
+				case "MACOS_INTEL_WORKAROUND_MATERIAL_CASES":
+					return "return " + generateFetchMaterialCases(0, MAX_MATERIALS) + ";";
 			}
 			return null;
 		});

--- a/src/main/java/rs117/hd/HdPlugin.java
+++ b/src/main/java/rs117/hd/HdPlugin.java
@@ -711,7 +711,8 @@ public class HdPlugin extends Plugin implements DrawCallbacks
 				case "MAX_MATERIALS":
 					return String.format("#define %s %d\n", key, MAX_MATERIALS);
 				case "CONST_MACOS_INTEL_WORKAROUND":
-					return String.format("#define %s %d\n", key, config.macosIntelWorkaround() ? 1 : 0);
+					boolean isAppleM1 = OSType.getOSType() == OSType.MacOS && System.getProperty("os.arch").equals("aarch64");
+					return String.format("#define %s %d\n", key, config.macosIntelWorkaround() && !isAppleM1 ? 1 : 0);
 				case "MACOS_INTEL_WORKAROUND_MATERIAL_CASES":
 					return "return " + generateFetchMaterialCases(0, MAX_MATERIALS) + ";";
 			}

--- a/src/main/java/rs117/hd/HdPluginConfig.java
+++ b/src/main/java/rs117/hd/HdPluginConfig.java
@@ -444,6 +444,7 @@ public interface HdPluginConfig extends Config
 			keyName = "macosIntelWorkaround",
 			name = "Fix shading on MacOS with Intel",
 			description = "Workaround for visual artifacts on some Intel GPU drivers on MacOS.",
+			warning = "This setting can cause RuneLite to crash, and can be difficult to revert. Only enable it if you\nare seeing black patches. Are you sure you want to enable the setting?",
 			position = 301,
 			section = workaroundSettings
 	)

--- a/src/main/resources/rs117/hd/frag.glsl
+++ b/src/main/resources/rs117/hd/frag.glsl
@@ -25,7 +25,7 @@
  */
 #version 330
 
-#define MAX_MATERIALS 200
+#include MAX_MATERIALS
 #define MAX_LIGHTS 100
 
 layout(std140) uniform uniforms {

--- a/src/main/resources/rs117/hd/shadow_frag.glsl
+++ b/src/main/resources/rs117/hd/shadow_frag.glsl
@@ -24,7 +24,7 @@
  */
 #version 330
 
-#define MAX_MATERIALS 200
+#include MAX_MATERIALS
 
 struct Material
 {

--- a/src/main/resources/rs117/hd/utils/fetch_material.glsl
+++ b/src/main/resources/rs117/hd/utils/fetch_material.glsl
@@ -28,11 +28,8 @@
 #if CONST_MACOS_INTEL_WORKAROUND
     // Workaround wrapper for drivers that do not support dynamic indexing,
     // particularly Intel drivers on MacOS
-    Material fetchMaterial(int index) {
-        switch (index) {
-            #include MACOS_INTEL_WORKAROUND_MATERIAL_CASES
-            default: return material[0];
-        }
+    Material fetchMaterial(int i) {
+        #include MACOS_INTEL_WORKAROUND_MATERIAL_CASES
     }
 #else
     #define fetchMaterial(index) material[index]


### PR DESCRIPTION
Change from switch cases to nested ifs, and add a warning in case the workaround still crashes on M1 systems.

I also modified `MAX_MATERIALS` to match the list of materials instead of being hard-coded. Feel free to mention it if you want it reverted.

Thanks to @keyosk for pointing out the performance difference, and for testing it again on Intel MacOS.