### PR TITLE
fix off by one texture lookup error

### DIFF
--- a/src/main/java/rs117/hd/materials/Material.java
+++ b/src/main/java/rs117/hd/materials/Material.java
@@ -358,7 +358,7 @@ public enum Material
 			{
 				DIFFUSE_ID_MATERIAL_MAP.put(material.diffuseMapId, material);
 
-				if (material.diffuseMapId > 0 && material.diffuseMapId < 9999) {
+				if (material.diffuseMapId >= 0 && material.diffuseMapId <= 9999) {
 					MATERIAL_DIFUSE_INDEX_MAP[material.diffuseMapId] = index;
 				}
 			}


### PR DESCRIPTION
was causing the "trapdoor" texture to be missing which resulted in a few bug reports