### PR TITLE
dynamically reload POH scene

### DIFF
--- a/src/main/java/rs117/hd/environments/EnvironmentManager.java
+++ b/src/main/java/rs117/hd/environments/EnvironmentManager.java
@@ -149,6 +149,12 @@ public class EnvironmentManager
 			{
 				if (environment != currentEnvironment)
 				{
+					if (environment == Environment.PLAYER_OWNED_HOUSE || environment == Environment.PLAYER_OWNED_HOUSE_SNOWY) {
+						hdPlugin.setInHouse(true);
+						hdPlugin.setNextSceneReload(System.currentTimeMillis() + 2500);
+					} else {
+						hdPlugin.setInHouse(false);
+					}
 					changeEnvironment(environment, camTargetX, camTargetY, false);
 				}
 				break;


### PR DESCRIPTION
This PR makes it to where the scene is reloaded whenever the player: enters a house, changes floors in the house, interacts with parts of the UI in a house, and maybe other things in a house. I noticed that client var 384 changing correlated with the performance decreases in POH. So this simply reloads the scene if that client var changes while the player is in a house. In my testing this totally fixes the POH performance problems on my machine. I also slightly refactored the way scene reloading works because I was inconsistently crashing with the old method with this fix.

Shoutout to Hooder, Keyosk, and everyone else in the RLHD Discord for helping me track this down :smile: 