### PR TITLE
add 16384 shadow resolution

### DIFF
--- a/src/main/java/rs117/hd/config/ShadowResolution.java
+++ b/src/main/java/rs117/hd/config/ShadowResolution.java
@@ -34,7 +34,8 @@ public enum ShadowResolution
 	RES_1024("Low (1024)", 1024),
 	RES_2048("Medium (2048)", 2048),
 	RES_4096("High (4096)", 4096),
-	RES_8192("Ultra (8192)", 8192);
+	RES_8192("Ultra (8192)", 8192),
+	RES_16384("Extreme (16384)", 16384);
 
 	private final String name;
 	private final int value;


### PR DESCRIPTION
This PR simply adds an "extreme" shadow resolution option. It does significantly increase GPU (+20%) and VRAM (+760MiB) usage on my 1660ti but users with high end systems might find the GPU usage acceptable for significantly crisper shadows when used with max shadow distance.  Thanks to Aeryn for the suggestion and help implementing/testing.