### PR TITLE
Bind dummy shadow map texture when shadows are disabled

### DIFF
--- a/src/main/java/rs117/hd/HdPlugin.java
+++ b/src/main/java/rs117/hd/HdPlugin.java
@@ -1098,6 +1098,7 @@ public class HdPlugin extends Plugin implements DrawCallbacks
 	{
 		if (!configShadowsEnabled)
 		{
+			initDummyShadowMap();
 			return;
 		}
 
@@ -1125,6 +1126,21 @@ public class HdPlugin extends Plugin implements DrawCallbacks
 		// Reset
 		gl.glBindTexture(gl.GL_TEXTURE_2D, 0);
 		gl.glBindFramebuffer(gl.GL_FRAMEBUFFER, 0);
+	}
+
+	private void initDummyShadowMap()
+	{
+		// Create texture
+		texShadowMap = glGenTexture(gl);
+		gl.glBindTexture(gl.GL_TEXTURE_2D, texShadowMap);
+		gl.glTexImage2D(gl.GL_TEXTURE_2D, 0, gl.GL_DEPTH_COMPONENT, 1, 1, 0, gl.GL_DEPTH_COMPONENT, gl.GL_FLOAT, null);
+		gl.glTexParameteri(gl.GL_TEXTURE_2D, gl.GL_TEXTURE_MIN_FILTER, gl.GL_NEAREST);
+		gl.glTexParameteri(gl.GL_TEXTURE_2D, gl.GL_TEXTURE_MAG_FILTER, gl.GL_NEAREST);
+		gl.glTexParameteri(gl.GL_TEXTURE_2D, gl.GL_TEXTURE_WRAP_S, gl.GL_CLAMP_TO_BORDER);
+		gl.glTexParameteri(gl.GL_TEXTURE_2D, gl.GL_TEXTURE_WRAP_T, gl.GL_CLAMP_TO_BORDER);
+
+		// Reset
+		gl.glBindTexture(gl.GL_TEXTURE_2D, 0);
 	}
 
 	private void shutdownShadowMapFbo()
@@ -1703,13 +1719,10 @@ public class HdPlugin extends Plugin implements DrawCallbacks
 
 			gl.glUseProgram(glProgram);
 
-			if (texShadowMap != -1)
-			{
-				// bind shadow map
-				gl.glActiveTexture(gl.GL_TEXTURE3);
-				gl.glBindTexture(GL_TEXTURE_2D, texShadowMap);
-				gl.glActiveTexture(gl.GL_TEXTURE0);
-			}
+			// bind shadow map, or dummy 1x1 texture
+			gl.glActiveTexture(gl.GL_TEXTURE3);
+			gl.glBindTexture(GL_TEXTURE_2D, texShadowMap);
+			gl.glActiveTexture(gl.GL_TEXTURE0);
 
 			if (aaEnabled)
 			{


### PR DESCRIPTION
Apparently on some M1 systems, the following warning is thrown (once) when no texture is bound to the `shadowMap` sampler:
```
UNSUPPORTED (log once): POSSIBLE ISSUE: unit 1 GLD_TEXTURE_INDEX_2D is unloadable and bound to sampler type (Float) - using zero texture because texture unloadable
```
See Discord for confirmation:
https://discord.com/channels/886733267284398130/887408540988350475/917896872381788190

This is largely unnecessary to fix, but may save some developer's time in the future, as the error message is somewhat misleading.