### PR TITLE
Preserves vanilla tile colours when Ground configs are disabled

### DIFF
--- a/src/main/java/rs117/hd/SceneUploader.java
+++ b/src/main/java/rs117/hd/SceneUploader.java
@@ -778,7 +778,7 @@ class SceneUploader
 				nwMaterial = groundMaterial.getRandomMaterial(tileZ, baseX + tileX, baseY + tileY + 1);
 				neMaterial = groundMaterial.getRandomMaterial(tileZ, baseX + tileX + 1, baseY + tileY + 1);
 			}
-			else
+			else if (hdPlugin.configWinterTheme)
 			{
 				if (client.getScene().getOverlayIds()[tileZ][tileX][tileY] != 0)
 				{
@@ -1150,7 +1150,7 @@ class SceneUploader
 				materialB = groundMaterial.getRandomMaterial(tileZ, baseX + tileX + (int) Math.floor((float) localVertices[1][0] / Perspective.LOCAL_TILE_SIZE), baseY + tileY + (int) Math.floor((float) localVertices[1][1] / Perspective.LOCAL_TILE_SIZE));
 				materialC = groundMaterial.getRandomMaterial(tileZ, baseX + tileX + (int) Math.floor((float) localVertices[2][0] / Perspective.LOCAL_TILE_SIZE), baseY + tileY + (int) Math.floor((float) localVertices[2][1] / Perspective.LOCAL_TILE_SIZE));
 			}
-			else
+			else if (hdPlugin.configWinterTheme)
 			{
 				if (proceduralGenerator.isOverlayFace(tile, face))
 				{


### PR DESCRIPTION
The addition of the Winter Theme rolled back one of the fixes in #167. The fix allowed tiles to use their vanilla colours unless using the Ground configs (Textures and/or Blending). With the addition of the Winter Theme, tile recolouring now occurs even with all Ground options disabled.

This PR adds a final check for `configWinterTheme` before applying tile recolouring. With `configGroundTextures`, `configGroundBlending` and `configWinterTheme` disabled, tiles will correctly use their vanilla colours.

Closes #196 .