### PR TITLE
Port GPU plugin fixes for stretched mode on MacOS

### DIFF
--- a/src/main/java/rs117/hd/HdPlugin.java
+++ b/src/main/java/rs117/hd/HdPlugin.java
@@ -44,7 +44,11 @@ import com.jogamp.opengl.GLFBODrawable;
 import com.jogamp.opengl.GLProfile;
 import com.jogamp.opengl.math.Matrix4;
 import java.awt.Canvas;
+import java.awt.Component;
 import java.awt.Color;
+import java.awt.event.ComponentAdapter;
+import java.awt.event.ComponentEvent;
+import java.awt.event.ComponentListener;
 import java.awt.Dimension;
 import java.awt.Graphics2D;
 import java.awt.Image;
@@ -410,6 +414,24 @@ public class HdPlugin extends Plugin implements DrawCallbacks
 
 	public int[] camTarget = new int[3];
 
+	private int needsReset;
+
+	private final ComponentListener resizeListener = new ComponentAdapter()
+	{
+		@Override
+		public void componentResized(ComponentEvent e)
+		{
+			// forward to the JAWTWindow component listener on the canvas. The JAWTWindow component
+			// listener listens for resizes or movement of the component in order to resize and move
+			// the associated offscreen layer (calayer on macos only)
+			canvas.dispatchEvent(e);
+			// resetSize needs to be run awhile after the resize is completed.
+			// I've tried waiting until all EDT events are completed and even that is too soon.
+			// Not sure why, so we just wait a few frames.
+			needsReset = 5;
+		}
+	};
+
 	@Override
 	protected void startUp()
 	{
@@ -579,6 +601,13 @@ public class HdPlugin extends Plugin implements DrawCallbacks
 				{
 					invokeOnMainThread(this::uploadScene);
 				}
+
+				if (OSType.getOSType() == OSType.MacOS)
+				{
+					SwingUtilities.invokeAndWait(() -> ((Component) client).addComponentListener(resizeListener));
+					needsReset = 5; // plugin startup races with ClientUI positioning, so do a reset in a little bit
+				}
+
 				startUpCompleted = true;
 			}
 			catch (Throwable e)
@@ -594,6 +623,8 @@ public class HdPlugin extends Plugin implements DrawCallbacks
 	protected void shutDown()
 	{
 		startUpCompleted = false;
+
+		((Component) client).removeComponentListener(resizeListener);
 
 		lightManager.reset();
 
@@ -1475,16 +1506,22 @@ public class HdPlugin extends Plugin implements DrawCallbacks
 			gl.glBindTexture(gl.GL_TEXTURE_2D, interfaceTexture);
 			gl.glTexImage2D(gl.GL_TEXTURE_2D, 0, gl.GL_RGBA, canvasWidth, canvasHeight, 0, gl.GL_BGRA, gl.GL_UNSIGNED_BYTE, null);
 			gl.glBindTexture(gl.GL_TEXTURE_2D, 0);
+		}
 
-			if (OSType.getOSType() == OSType.MacOS && glDrawable instanceof GLFBODrawable)
+		if (needsReset > 0)
+		{
+			assert OSType.getOSType() == OSType.MacOS;
+			if (needsReset == 1 && glDrawable instanceof GLFBODrawable)
 			{
 				// GLDrawables created with createGLDrawable() do not have a resize listener
 				// I don't know why this works with Windows/Linux, but on OSX
 				// it prevents JOGL from resizing its FBOs and underlying GL textures. So,
 				// we manually trigger a resize here.
 				GLFBODrawable glfboDrawable = (GLFBODrawable) glDrawable;
+				log.debug("Resetting GLFBODrawable size");
 				glfboDrawable.resetSize(gl);
 			}
+			needsReset--;
 		}
 
 		final BufferProvider bufferProvider = client.getBufferProvider();


### PR DESCRIPTION
This ports GPU plugin commits https://github.com/runelite/runelite/commit/bb43d232bb594c6e062e3342fa7db1b53f594c11 and https://github.com/runelite/runelite/commit/637ee563d622fa187b2e4537ade86979bad1dbc9.

All credits for these fixes go to Adam.