### PR TITLE
log client arch

### DIFF
--- a/src/main/java/rs117/hd/HdPlugin.java
+++ b/src/main/java/rs117/hd/HdPlugin.java
@@ -478,6 +478,7 @@ public class HdPlugin extends Plugin implements DrawCallbacks
 					GL versionGL = versionContext.getGL().getGL();
 					log.info("Using device: {}", versionGL.glGetString(GL.GL_RENDERER));
 					log.info("Using driver: {}", versionGL.glGetString(GL.GL_VERSION));
+					log.info("Client is {}-bit", System.getProperty("sun.arch.data.model"));
 					versionContext.destroy();
 
 					GLProfile glProfile = GLProfile.get(GLProfile.GL4);


### PR DESCRIPTION
One of the first steps we ask users in the Windows support channel to do is post their logs and to open task manager and check if they're running 32-bit or 64-bit Runelite. This eliminates a step by logging the info we're looking for.

```
[Client] INFO  rs117.hd.HdPlugin - Using device: NVIDIA GeForce RTX 2070 SUPER/PCIe/SSE2
[Client] INFO  rs117.hd.HdPlugin - Using driver: 4.6.0 NVIDIA 511.23
[Client] INFO  rs117.hd.HdPlugin - Client is 64-bit
```