### PR TITLE
Refactor count_prio_offset method to reduce branches

### DIFF
--- a/src/main/resources/rs117/hd/priority_render.glsl
+++ b/src/main/resources/rs117/hd/priority_render.glsl
@@ -70,44 +70,14 @@ int priority_map(int p, int distance, int _min10, int avg1, int avg2, int avg3) 
 // the given adjusted priority
 int count_prio_offset(int priority) {
     int total = 0;
-    switch (priority) {
-        case 17:
-        total += totalMappedNum[16];
-        case 16:
-        total += totalMappedNum[15];
-        case 15:
-        total += totalMappedNum[14];
-        case 14:
-        total += totalMappedNum[13];
-        case 13:
-        total += totalMappedNum[12];
-        case 12:
-        total += totalMappedNum[11];
-        case 11:
-        total += totalMappedNum[10];
-        case 10:
-        total += totalMappedNum[9];
-        case 9:
-        total += totalMappedNum[8];
-        case 8:
-        total += totalMappedNum[7];
-        case 7:
-        total += totalMappedNum[6];
-        case 6:
-        total += totalMappedNum[5];
-        case 5:
-        total += totalMappedNum[4];
-        case 4:
-        total += totalMappedNum[3];
-        case 3:
-        total += totalMappedNum[2];
-        case 2:
-        total += totalMappedNum[1];
-        case 1:
-        total += totalMappedNum[0];
-        case 0:
-        return total;
+    // The previous switch statements supported at most 17 priorities
+    if (priority > 17) {
+        priority = 17;
     }
+    for (int i = 1; i <= priority; i++) {
+        total += totalMappedNum[i-1];
+    }
+    return total;
 }
 
 void get_face(uint localId, modelinfo minfo, int cameraYaw, int cameraPitch,


### PR DESCRIPTION
Fixes #209

It seems like there's some undefined behavior with Nvidia and too many branches. The return at the bottom of the switch statement doesn't appear to be getting called.