### PR TITLE
opencl: replace count_prio_offset switch with loop

### DIFF
--- a/src/main/resources/rs117/hd/priority_render.cl
+++ b/src/main/resources/rs117/hd/priority_render.cl
@@ -62,52 +62,21 @@ int priority_map(int p, int distance, int _min10, int avg1, int avg2, int avg3) 
         return 17;
       }
     default:
-      return -1;
+      // this can't happen unless an invalid priority is sent. just assume 0.
+      return 0;
   }
 }
 
 // calculate the number of faces with a lower adjusted priority than
 // the given adjusted priority
 int count_prio_offset(__local struct shared_data *shared, int priority) {
+  // this shouldn't ever be outside of (0, 17) because it is the return value from priority_map
+  priority = clamp(priority, 0, 17);
   int total = 0;
-  switch (priority) {
-    case 17:
-      total += shared->totalMappedNum[16];
-    case 16:
-      total += shared->totalMappedNum[15];
-    case 15:
-      total += shared->totalMappedNum[14];
-    case 14:
-      total += shared->totalMappedNum[13];
-    case 13:
-      total += shared->totalMappedNum[12];
-    case 12:
-      total += shared->totalMappedNum[11];
-    case 11:
-      total += shared->totalMappedNum[10];
-    case 10:
-      total += shared->totalMappedNum[9];
-    case 9:
-      total += shared->totalMappedNum[8];
-    case 8:
-      total += shared->totalMappedNum[7];
-    case 7:
-      total += shared->totalMappedNum[6];
-    case 6:
-      total += shared->totalMappedNum[5];
-    case 5:
-      total += shared->totalMappedNum[4];
-    case 4:
-      total += shared->totalMappedNum[3];
-    case 3:
-      total += shared->totalMappedNum[2];
-    case 2:
-      total += shared->totalMappedNum[1];
-    case 1:
-      total += shared->totalMappedNum[0];
-    case 0:
-      return total;
+  for (int i = 0; i < priority; i++) {
+    total += shared->totalMappedNum[i];
   }
+  return total;
 }
 
 void get_face(

--- a/src/main/resources/rs117/hd/priority_render.glsl
+++ b/src/main/resources/rs117/hd/priority_render.glsl
@@ -62,20 +62,19 @@ int priority_map(int p, int distance, int _min10, int avg1, int avg2, int avg3) 
             return 17;
         }
         default:
-        return -1;
+        // this can't happen unless an invalid priority is sent. just assume 0.
+        return 0;
     }
 }
 
 // calculate the number of faces with a lower adjusted priority than
 // the given adjusted priority
 int count_prio_offset(int priority) {
+    // this shouldn't ever be outside of (0, 17) because it is the return value from priority_map
+    priority = clamp(priority, 0, 17);
     int total = 0;
-    // The previous switch statements supported at most 17 priorities
-    if (priority > 17) {
-        priority = 17;
-    }
-    for (int i = 1; i <= priority; i++) {
-        total += totalMappedNum[i-1];
+    for (int i = 0; i < priority; i++) {
+        total += totalMappedNum[i];
     }
     return total;
 }


### PR DESCRIPTION
Thanks to Adam for this refactor

https://github.com/Adam-/runelite/commit/bc5beb5304eb0b911538d558dd433bf09cd04b9c

I've tested this on a 2019 MBP with AMD dGPU, and a 2013 MBP With Nvidia dGPU, and Intel Iris Pro iGPU.