### PR TITLE
reload scene when opening a new room in the gauntlet

### DIFF
--- a/src/main/java/rs117/hd/HdPlugin.java
+++ b/src/main/java/rs117/hd/HdPlugin.java
@@ -400,6 +400,21 @@ public class HdPlugin extends Plugin implements DrawCallbacks
 
 	private int needsReset;
 
+	@Setter
+	private boolean isInGauntlet = false;
+
+	@Subscribe
+	public void onChatMessage(final ChatMessage event) {
+		if (!isInGauntlet) {
+			return;
+		}
+
+		// reload the scene if the player is in the gauntlet and opening a new room to pull the new data into the buffer
+		if (event.getMessage().equals("You light the nodes in the corridor to help guide the way.")) {
+			reloadScene();
+		}
+	}
+
 	private final ComponentListener resizeListener = new ComponentAdapter()
 	{
 		@Override

--- a/src/main/java/rs117/hd/environments/EnvironmentManager.java
+++ b/src/main/java/rs117/hd/environments/EnvironmentManager.java
@@ -155,6 +155,9 @@ public class EnvironmentManager
 					} else {
 						hdPlugin.setInHouse(false);
 					}
+
+					hdPlugin.setInGauntlet(environment == Environment.THE_GAUNTLET || environment == Environment.THE_GAUNTLET_CORRUPTED);
+
 					changeEnvironment(environment, camTargetX, camTargetY, false);
 				}
 				break;


### PR DESCRIPTION
Testing with @keyosk confirms that the scene buffer does not stay up to date in the gauntlet. The framerate rapidly degrades as more rooms are opened up. What's odd though is that the logs clearly indicate that the gamestate is changing and the scene is uploading but there must be a race condition that this patch fixes. @keyosk reports that while playing with the reduced allocations branch his FPS drops below 100 after opening several rooms but with this patch and the reduced allocations the FPS stays steady in the upper 100s.