### PR TITLE
Update default config & descriptions

### DIFF
--- a/src/main/java/rs117/hd/HdPluginConfig.java
+++ b/src/main/java/rs117/hd/HdPluginConfig.java
@@ -139,7 +139,7 @@ public interface HdPluginConfig extends Config
 	@ConfigItem(
 		keyName = "unlockFps",
 		name = "Unlock FPS",
-		description = "Removes the 50 FPS cap for camera movement, lighting and shadows.",
+		description = "Removes the 50 FPS cap for some game content such as camera movement and dynamic lighting.",
 		position = 5,
 		section = generalSettings
 	)
@@ -271,7 +271,7 @@ public interface HdPluginConfig extends Config
 	@ConfigItem(
 		keyName = "maxDynamicLights",
 		name = "Dynamic Lights",
-		description = "The maximum number of dynamic lights visible at one time. GPU-heavy in certain scenes.",
+		description = "The maximum number of dynamic lights visible at one time. Reducing this will improve performance.",
 		position = 101,
 		section = lightingSettings
 	)


### PR DESCRIPTION
There are 7 changes here, some may not be wanted but i thought i would post them to get some opinions and discussion going. 

If you are in favor or against anything in particular, post a comment.

Here's what i changed and why:

AA description:
A little bit clearer IMO. The warning about 8x/16x may help some people who are unintentionally maxing out their GPU's and information is added about this specifically being GPU load - the CPU is practically unaffected.

AF description:
Specifies that the range is from 0 to 16x. This is not otherwise obvious and because the setting is a box rather than a dropdown, some people aren't aware that they can/should set it higher.

AF default of 16x, up from 1x:
I'm not sure if there is a good reason that we can't do this, however 16x AF is visually impactful and practically free from a performance standpoint even on low-end hardware. Some users have been caught out, not realising that this is set incorrectly low on their systems - i wouldn't want to cause any compatibility problem, though.

unlockFPS description:
Note that the shadow and lighting systems also operate on the unlocked framerate, not just the camera. This is a common misconception which stems from copying the description from the GPU plugin which did not have those features.

FPS target floor:
Allows a setting of 0 which turns off the cap system entirely. I used this for a little while and did not see any problem, but it's no big deal.

Dynamic Lights description:
Specifies that the increased workload from this setting only applies in certain scenes and that the added load is on the GPU.
CPU-bound users can increase this setting without a framerate change, just as they can for MSAA.

Shadow Quality description:
Specifies that the performance cost is for the GPU.

-----

Some of the other graphics options mention a performance cost without specifying CPU or GPU - i left those as they were because they generally affect both; things like view distance and enabling or disabling shadows altogether.

Some of these descriptions can help from a support standpoint because we can tell users not to use too many of the settings which are labeled as GPU-intensive at once, for example.