### PR TITLE
Fix cutscene viewport offsets in resizeable mode

### DIFF
--- a/src/main/java/rs117/hd/HdPlugin.java
+++ b/src/main/java/rs117/hd/HdPlugin.java
@@ -72,6 +72,8 @@ import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.*;
 import net.runelite.api.events.*;
 import net.runelite.api.hooks.DrawCallbacks;
+import net.runelite.api.widgets.Widget;
+import net.runelite.api.widgets.WidgetID;
 import net.runelite.client.callback.ClientThread;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.eventbus.Subscribe;
@@ -1628,6 +1630,19 @@ public class HdPlugin extends Plugin implements DrawCallbacks
 			int renderCanvasHeight = canvasHeight;
 			int renderViewportHeight = viewportHeight;
 			int renderViewportWidth = viewportWidth;
+
+			// Fix viewport offset for cutscenes in resizeable mode
+			if (client.isResized())
+			{
+				Widget viewportWidget = client.getWidget(WidgetID.RESIZABLE_VIEWPORT_BOTTOM_LINE_GROUP_ID, 87);
+				if (viewportWidget != null)
+				{
+					renderWidthOff = viewportWidget.getRelativeX();
+					renderHeightOff = viewportWidget.getRelativeY();
+					renderViewportWidth = viewportWidget.getWidth();
+					renderViewportHeight = viewportWidget.getHeight();
+				}
+			}
 
 			// Setup anisotropic filtering
 			final int anisotropicFilteringLevel = config.anisotropicFilteringLevel();

--- a/src/main/java/rs117/hd/HdPlugin.java
+++ b/src/main/java/rs117/hd/HdPlugin.java
@@ -404,6 +404,7 @@ public class HdPlugin extends Plugin implements DrawCallbacks
 
 	@Setter
 	private boolean isInGauntlet = false;
+	private boolean isInCutscene = false;
 
 	@Subscribe
 	public void onChatMessage(final ChatMessage event) {
@@ -1632,7 +1633,7 @@ public class HdPlugin extends Plugin implements DrawCallbacks
 			int renderViewportWidth = viewportWidth;
 
 			// Fix viewport offset for cutscenes in resizeable mode
-			if (client.isResized())
+			if (client.isResized() && isInCutscene)
 			{
 				Widget viewportWidget = client.getWidget(WidgetID.RESIZABLE_VIEWPORT_BOTTOM_LINE_GROUP_ID, 87);
 				if (viewportWidget != null)
@@ -2775,5 +2776,11 @@ public class HdPlugin extends Plugin implements DrawCallbacks
 	{
 		GroundObject groundObject = groundObjectDespawned.getGroundObject();
 		lightManager.removeObjectLight(groundObject);
+	}
+
+	@Subscribe
+	public void onVarbitChanged(VarbitChanged e)
+	{
+		isInCutscene = (client.getVarbitValue(client.getVarps(), 4606) == 1);
 	}
 }


### PR DESCRIPTION
Closes #172 and #188.

I haven't playtested this a lot, but I think this widget should be reliable.

Arguably the bug might be better off fixed internally within RuneLite, as there is already code for getting the viewport offset, but it's currently broken for cutscenes in resizeable mode. This is currently broken in the regular GPU plugin as well.