### PR TITLE
draw loading and connection lost boxes

### DIFF
--- a/src/main/java/rs117/hd/HdPlugin.java
+++ b/src/main/java/rs117/hd/HdPlugin.java
@@ -1576,7 +1576,11 @@ public class HdPlugin extends Plugin implements DrawCallbacks
 			}
 		}
 
-		camTarget = getCameraFocalPoint();
+		GameState gs = client.getGameState();
+		if (gs != GameState.LOADING)
+		{
+			camTarget = getCameraFocalPoint();
+		}
 
 		// shader variables for water, lava animations
 		animationCurrent += (System.currentTimeMillis() - lastFrameTime) / 1000f;
@@ -1689,8 +1693,6 @@ public class HdPlugin extends Plugin implements DrawCallbacks
 			Matrix4 lightProjectionMatrix = new Matrix4();
 			float lightPitch = environmentManager.currentLightPitch;
 			float lightYaw = environmentManager.currentLightYaw;
-
-			GameState gs = client.getGameState();
 
 			if (loggedIn && (gs == GameState.LOGGED_IN || gs == GameState.LOADING) && configShadowsEnabled && fboShadowMap != -1 && environmentManager.currentDirectionalStrength > 0.0f)
 			{

--- a/src/main/java/rs117/hd/HdPlugin.java
+++ b/src/main/java/rs117/hd/HdPlugin.java
@@ -306,6 +306,8 @@ public class HdPlugin extends Plugin implements DrawCallbacks
 
 	private int yaw;
 	private int pitch;
+	private int viewportOffsetX;
+	private int viewportOffsetY;
 
 	// Uniforms
 	private int uniColorBlindMode;
@@ -1192,6 +1194,8 @@ public class HdPlugin extends Plugin implements DrawCallbacks
 	{
 		yaw = client.getCameraYaw();
 		pitch = client.getCameraPitch();
+		viewportOffsetX = client.getViewportXOffset();
+		viewportOffsetY = client.getViewportYOffset();
 
 		final Scene scene = client.getScene();
 		scene.setDrawDistance(getDrawDistance());
@@ -1618,8 +1622,8 @@ public class HdPlugin extends Plugin implements DrawCallbacks
 			final int viewportHeight = client.getViewportHeight();
 			final int viewportWidth = client.getViewportWidth();
 
-			int renderHeightOff = client.getViewportYOffset();
-			int renderWidthOff = client.getViewportXOffset();
+			int renderWidthOff = viewportOffsetX;
+			int renderHeightOff = viewportOffsetY;
 			int renderCanvasHeight = canvasHeight;
 			int renderViewportHeight = viewportHeight;
 			int renderViewportWidth = viewportWidth;

--- a/src/main/java/rs117/hd/HdPlugin.java
+++ b/src/main/java/rs117/hd/HdPlugin.java
@@ -402,8 +402,6 @@ public class HdPlugin extends Plugin implements DrawCallbacks
 	@Setter
 	private boolean isInGauntlet = false;
 
-	private boolean loggedIn = false;
-
 	@Subscribe
 	public void onChatMessage(final ChatMessage event) {
 		if (!isInGauntlet) {
@@ -1580,7 +1578,7 @@ public class HdPlugin extends Plugin implements DrawCallbacks
 
 		// Draw 3d scene
 		final TextureProvider textureProvider = client.getTextureProvider();
-		if (loggedIn && textureProvider != null)
+		if (textureProvider != null && client.getGameState().getState() >= GameState.LOADING.getState())
 		{
 			final Texture[] textures = textureProvider.getTextures();
 			if (textureArrayId == -1)
@@ -2140,14 +2138,12 @@ public class HdPlugin extends Plugin implements DrawCallbacks
 	{
 		switch (gameStateChanged.getGameState()) {
 			case LOGGED_IN:
-				loggedIn = true;
 				lastFrameTime = System.currentTimeMillis();
 				invokeOnMainThread(this::uploadScene);
 				break;
 			case LOGIN_SCREEN:
 				// Avoid drawing the last frame's buffer during LOADING after LOGIN_SCREEN
 				targetBufferOffset = 0;
-				loggedIn = false;
 			default:
 				lightManager.reset();
 		}


### PR DESCRIPTION
This reintroduces https://github.com/runelite/runelite/commit/6f5735be077e74e3790b9163bcf8d2684eedbb00

But with the logic fixed so that shadows can be drawn while the loading is happening as well. I believe this also fixes the screen flickering that some users have reported during loading. https://github.com/RS117/RLHD/issues/199 in particular seems to be fixed by these changes.