### PR TITLE
fix buffer corruption after OS suspend

### DIFF
--- a/src/main/java/rs117/hd/HdPlugin.java
+++ b/src/main/java/rs117/hd/HdPlugin.java
@@ -367,7 +367,7 @@ public class HdPlugin extends Plugin implements DrawCallbacks
 	private int uniBlockPointLights;
 
 	// Animation things
-	private long lastFrameTime;
+	private long lastFrameTime = System.currentTimeMillis();
 	// Generic scalable animation timer used in shaders
 	private float animationCurrent = 0;
 
@@ -1576,6 +1576,10 @@ public class HdPlugin extends Plugin implements DrawCallbacks
 			startUp();
 		}
 
+		// shader variables for water, lava animations
+		animationCurrent += (System.currentTimeMillis() - lastFrameTime) / 1000f;
+		lastFrameTime = System.currentTimeMillis();
+
 		final int canvasHeight = client.getCanvasHeight();
 		final int canvasWidth = client.getCanvasWidth();
 
@@ -1934,9 +1938,6 @@ public class HdPlugin extends Plugin implements DrawCallbacks
 			// Bind directional light projection matrix
 			gl.glUniformMatrix4fv(uniLightProjectionMatrix, 1, false, lightProjectionMatrix.getMatrix(), 0);
 
-			// shader variables for water, lava animations
-			animationCurrent += (System.currentTimeMillis() - lastFrameTime) / 1000f;
-			lastFrameTime = System.currentTimeMillis();
 
 			// Bind uniforms
 			gl.glUniformBlockBinding(glProgram, uniBlockMain, 0);
@@ -2146,7 +2147,6 @@ public class HdPlugin extends Plugin implements DrawCallbacks
 	{
 		switch (gameStateChanged.getGameState()) {
 			case LOGGED_IN:
-				lastFrameTime = System.currentTimeMillis();
 				invokeOnMainThread(this::uploadScene);
 				break;
 			case LOGIN_SCREEN:

--- a/src/main/java/rs117/hd/HdPlugin.java
+++ b/src/main/java/rs117/hd/HdPlugin.java
@@ -1568,6 +1568,14 @@ public class HdPlugin extends Plugin implements DrawCallbacks
 	{
 		assert jawtWindow.getAWTComponent() == client.getCanvas() : "canvas invalidated";
 
+		// reset the plugin if the last frame took >1min to draw
+		// why? because the user's computer was probably suspended and the buffers are no longer valid
+		if (System.currentTimeMillis() - lastFrameTime > 60000) {
+			log.debug("resetting the plugin after probable OS suspend");
+			shutDown();
+			startUp();
+		}
+
 		final int canvasHeight = client.getCanvasHeight();
 		final int canvasWidth = client.getCanvasWidth();
 


### PR DESCRIPTION
Addresses #210 

I was able to reproduce the bug with the following steps:
1) log in
2) log out
3) suspend computer for 1 minute
4) log in

The effects seems kind of random. This is what it [looked like](https://cdn.discordapp.com/attachments/886739974555316294/945196921000173629/suspend-glitch.png) on one attempt.