### PR TITLE
prevent ArrayIndexOutOfBoundsException on hash collision

### DIFF
--- a/src/main/java/rs117/hd/ModelPusher.java
+++ b/src/main/java/rs117/hd/ModelPusher.java
@@ -14,6 +14,16 @@ import java.util.WeakHashMap;
 
 class ModelData {
     private int[] colors;
+    private int faceCount;
+
+    public int getFaceCount() {
+        return faceCount;
+    }
+
+    public ModelData setFaceCount(int faceCount) {
+        this.faceCount = faceCount;
+        return this;
+    }
 
     public ModelData setColors(int[] colors) {
         this.colors = colors;
@@ -284,8 +294,9 @@ public class ModelPusher {
         int hash = hasher.hashCode(eightInts);
 
         ModelData modelData = modelCache.get(hash);
-        if (modelData == null) {
-            modelData = new ModelData().setColors(getColorsForModel(model, objectProperties, objectType, tileX, tileY, tileZ, faceCount));
+        if (modelData == null || modelData.getFaceCount() != model.getFaceCount()) {
+            // get new data if there was no cache or if we detected an exception causing hash collision
+            modelData = new ModelData().setColors(getColorsForModel(model, objectProperties, objectType, tileX, tileY, tileZ, faceCount)).setFaceCount(model.getFaceCount());
             modelCache.put(hash, modelData);
         }
 


### PR DESCRIPTION
User c-pin in the Discord [uploaded](https://discord.com/channels/886733267284398130/886739001837498418/945203601729544203) a `client.log` of a crash that seems to be caused by hash collision of two models with different vertex counts. Given that hash collisions seem to be very rare this simply gets fresh data if the cached data has a different face count than the model.

Despite being unable to reproduce the crash I'm fairly certain this will prevent it from happening. 