### PR TITLE
Fix loading gluegen natives on some Windows configurations

### DIFF
--- a/src/main/java/rs117/hd/HdPlugin.java
+++ b/src/main/java/rs117/hd/HdPlugin.java
@@ -481,6 +481,8 @@ public class HdPlugin extends Plugin implements DrawCallbacks
 					System.setProperty("jogl.debug", "true");
 				}
 
+				System.setProperty("jogamp.gluegen.UseNativeExeFile", "true");
+
 				GLProfile.initSingleton();
 
 				invokeOnMainThread(() ->


### PR DESCRIPTION
This commit works around a bug with loading natives when the user's home folder contains special characters such as `&`, `^` or `!`. For further details, see the PR over at runelite/runelite#14712.