### PR TITLE
Fixed blue frame on login

### DIFF
--- a/src/main/java/rs117/hd/HdPlugin.java
+++ b/src/main/java/rs117/hd/HdPlugin.java
@@ -1696,7 +1696,7 @@ public class HdPlugin extends Plugin implements DrawCallbacks
 			float lightPitch = environmentManager.currentLightPitch;
 			float lightYaw = environmentManager.currentLightYaw;
 
-			if (configShadowsEnabled && fboShadowMap != -1 && environmentManager.currentDirectionalStrength > 0.0f)
+			if ((client.getGameState() == GameState.LOGGED_IN || client.getGameState() == GameState.LOADING) && configShadowsEnabled && fboShadowMap != -1 && environmentManager.currentDirectionalStrength > 0.0f)
 			{
 				// render shadow depth map
 				gl.glViewport(0, 0, config.shadowResolution().getValue(), config.shadowResolution().getValue());

--- a/src/main/java/rs117/hd/HdPlugin.java
+++ b/src/main/java/rs117/hd/HdPlugin.java
@@ -1565,6 +1565,11 @@ public class HdPlugin extends Plugin implements DrawCallbacks
 
 	private void drawFrame(int overlayColor)
 	{
+	        if (client.getGameState() == GameState.LOADING || client.getGameState() == GameState.HOPPING)
+		{
+			// While the client is loading it doesn't draw
+			return;
+		}
 		assert jawtWindow.getAWTComponent() == client.getCanvas() : "canvas invalidated";
 
 		// reset the plugin if the last frame took >1min to draw


### PR DESCRIPTION
When logging into OSRS with RLHD, there is now a blue frame. This is a regression caused by removing some checks in code, I have fixed it by adding back the code.

Here is a video of the bug: https://streamable.com/20qsrm

You can see the blue frame here: https://i.imgur.com/sFiKU81.png