### PR TITLE
Improve shadow threshold

### DIFF
--- a/src/main/resources/rs117/hd/shadow_frag.glsl
+++ b/src/main/resources/rs117/hd/shadow_frag.glsl
@@ -75,7 +75,7 @@ void main()
     uv = vec2((uv.x - 0.5) / material[materialId].textureScale.x + 0.5, (uv.y - 0.5) / material[materialId].textureScale.y + 0.5);
     vec4 texture = texture(texturesHD, vec3(uv, material[materialId].diffuseMapId));
 
-    if (min(texture.a, alpha) < 0.3)
+    if (min(texture.a, alpha) < 0.75)
     {
         discard;
     }

--- a/src/main/resources/rs117/hd/shadow_frag.glsl
+++ b/src/main/resources/rs117/hd/shadow_frag.glsl
@@ -75,7 +75,7 @@ void main()
     uv = vec2((uv.x - 0.5) / material[materialId].textureScale.x + 0.5, (uv.y - 0.5) / material[materialId].textureScale.y + 0.5);
     vec4 texture = texture(texturesHD, vec3(uv, material[materialId].diffuseMapId));
 
-    if (min(texture.a, alpha) < 0.75)
+    if (min(texture.a, alpha) < 0.85)
     {
         discard;
     }


### PR DESCRIPTION
Objects are prevented from casting shadows if their transparency is below X threshold.

If this threshold is too low, semitransparent objects may cast shadows when they're not supposed to or animated objects with variable transparency may cast shadows for part of their animation but not the rest of it - thus causing sharp strobing shadows.

If the threshold is too high, some objects which are supposed to cast shadows do not.

This was previously discussed in https://github.com/RS117/RLHD/issues/56 and the threshold was bumped from 0.25 to 0.3 to fix this specific case, but i continued to experiment and discuss other cases since then.

I've made a spreadsheet of affected objects here - https://docs.google.com/spreadsheets/d/16UIcbYeTgiubOE6nnOTjvZRabG80ZuxxPxFTIcLfnwY/edit#gid=0. Most things work over 0.35, but loot beams from the ground items default plugin require 0.55. For an upper bound on what the threshold can be, the only problem that i found with a high value was part of some bat wings missing when set to over 0.85. 

In general, leaning high on the threshold is best IMO. The unintentional shadows and strobing shadows which can appear with too low of a threshold are a lot more distracting than maybe an occasional object not casting a shadow when it should. From many days of gameplay i've found several cases which are fixed with a higher threshold than 0.3 but nothing that broke below 0.85, so i think 0.75 is a good value to work from.

