### PR TITLE
Override environment sky option

### DIFF
--- a/src/main/java/rs117/hd/HdPluginConfig.java
+++ b/src/main/java/rs117/hd/HdPluginConfig.java
@@ -413,10 +413,21 @@ public interface HdPluginConfig extends Config
 	}
 
 	@ConfigItem(
+			keyName = "overrideSky",
+			name = "Override Sky Color",
+			description = "Forces the selected sky color in all environments",
+			position = 205,
+			section = environmentSettings
+	)
+	default boolean overrideSky() {
+		return false;
+	}
+
+	@ConfigItem(
 		keyName = "objectTextures",
 		name = "Object Textures",
 		description = "Adds detail textures to certain world objects.",
-		position = 205,
+		position = 206,
 		section = environmentSettings
 	)
 	default boolean objectTextures()
@@ -428,7 +439,7 @@ public interface HdPluginConfig extends Config
 		keyName = "groundTextures",
 		name = "Ground Textures",
 		description = "Adds detail textures to the ground.",
-		position = 206,
+		position = 207,
 		section = environmentSettings
 	)
 	default boolean groundTextures()
@@ -440,7 +451,7 @@ public interface HdPluginConfig extends Config
 			keyName = "groundBlending",
 			name = "Ground Blending",
 			description = "Affects the quality of blending between different ground/terrain textures.",
-			position = 207,
+			position = 208,
 			section = environmentSettings
 	)
 	default boolean groundBlending()
@@ -452,7 +463,7 @@ public interface HdPluginConfig extends Config
 		keyName = "waterEffects",
 		name = "Water Effects",
 		description = "Changes the appearance of the water.",
-		position = 208,
+		position = 209,
 		section = environmentSettings
 	)
 	default WaterEffects waterEffects()
@@ -464,7 +475,7 @@ public interface HdPluginConfig extends Config
 		keyName = "tzhaarHD",
 		name = "HD TzHaar Reskin",
 		description = "Recolors the TzHaar city of Mor Ul Rek to give it an appearance similar to that of its 2008 HD variant.",
-		position = 209,
+		position = 210,
 		section = environmentSettings
 	)
 	default boolean tzhaarHD()

--- a/src/main/java/rs117/hd/environments/Environment.java
+++ b/src/main/java/rs117/hd/environments/Environment.java
@@ -53,6 +53,7 @@ public enum Environment
 	RFD_QUIZ(Area.RFD_QUIZ, new Properties()
 		.setFogColor("#000000")
 		.setFogDepth(0)
+		.setAllowSkyOverride(false)
 	),
 	FROZEN_WASTE_PLATEAU(Area.FROZEN_WASTE_PLATEAU, new Properties()
 		.setFogColor("#252C37")
@@ -485,12 +486,14 @@ public enum Environment
 		.setFogDepth(30)
 		.setAmbientStrength(1.0f)
 		.setDirectionalStrength(0.0f)
+		.setAllowSkyOverride(false)
 	),
 	SOTE_LLETYA_ON_FIRE(Area.SOTE_LLETYA_ON_FIRE, new Properties()
 		.setFogColor(91, 139, 120)
 		.setFogDepth(50)
 		.setAmbientStrength(0.9f)
 		.setDirectionalStrength(0.0f)
+		.setAllowSkyOverride(false)
 	),
 	POSION_WASTE(Area.POISON_WASTE, new Properties()
 		.setFogColor(50, 55, 47)
@@ -512,9 +515,11 @@ public enum Environment
 		.setFogColor(18, 64, 83)
 		.setAmbientStrength(0.3f)
 		.setDirectionalStrength(1.0f)
+		.setAllowSkyOverride(false)
 	),
 	SOTE_FRAGMENT_OF_SEREN_ARENA(Area.SOTE_FRAGMENT_OF_SEREN_ARENA, new Properties()
 		.setFogColor(0, 0, 0)
+		.setAllowSkyOverride(false)
 	),
 
 	// Yanille
@@ -624,6 +629,7 @@ public enum Environment
 		.setDirectionalStrength(3.0f)
 		.setDirectionalColor("#57FF00")
 		.setLightDirection(260f, 10f)
+		.setAllowSkyOverride(false)
 	),
 	ZANARIS(Area.ZANARIS, new Properties()
 		.setFogColor(22, 63, 71)
@@ -642,6 +648,7 @@ public enum Environment
 		.setAmbientStrength(1.2f)
 		.setAmbientColor(255, 255, 255)
 		.setDirectionalStrength(0.0f)
+		.setAllowSkyOverride(false)
 	),
 	DS2_FLEET_ATTACKED(Area.DS2_FLEET_ATTACKED, new Properties()
 		.setFogColor("#FFD3C7")
@@ -715,6 +722,7 @@ public enum Environment
 		.setAmbientColor(255, 255, 255)
 		.setDirectionalStrength(0.0f)
 		.setLightDirection(260f, 10f)
+		.setAllowSkyOverride(false)
 	),
 
 	// Fishing Trawler
@@ -751,6 +759,7 @@ public enum Environment
 		.setDirectionalColor("#FFFFFF")
 		.setDirectionalStrength(0.0f)
 		.setLightDirection(260f, 10f)
+		.setAllowSkyOverride(false)
 	),
 
 	// Chambers of Xeric
@@ -773,6 +782,7 @@ public enum Environment
 		.setDirectionalStrength(2.0f)
 		.setDirectionalColor("#00FF60")
 		.setLightDirection(260f, 10f)
+		.setAllowSkyOverride(false)
 	),
 
 	// Underwater areas
@@ -816,6 +826,7 @@ public enum Environment
 		.setDirectionalColor("#CAB6CD")
 		.setDirectionalStrength(0.7f)
 		.setLightDirection(260f, 10f)
+		.setAllowSkyOverride(false)
 	),
 
 	// Runecrafting altars
@@ -830,6 +841,7 @@ public enum Environment
 		.setDirectionalColor("#FFFFFF")
 		.setDirectionalStrength(3.0f)
 		.setLightDirection(260f, 10f)
+		.setAllowSkyOverride(false)
 	),
 
 	TARNS_LAIR(Area.TARNS_LAIR, new Properties()
@@ -919,6 +931,7 @@ public enum Environment
 	private final float groundFogOpacity;
 	private final float lightPitch;
 	private final float lightYaw;
+	private final boolean allowSkyOverride;
 
 	private static class Properties
 	{
@@ -942,6 +955,7 @@ public enum Environment
 		private float groundFogOpacity = 0;
 		private float lightPitch = -128f;
 		private float lightYaw = 55f;
+		private boolean allowSkyOverride = true;
 
 		public Properties setFogDepth(int depth)
 		{
@@ -1048,6 +1062,11 @@ public enum Environment
 			this.lightYaw = yaw;
 			return this;
 		}
+		public Properties setAllowSkyOverride(boolean s)
+		{
+			this.allowSkyOverride = s;
+			return this;
+		}
 	}
 
 	Environment(Area area, Properties properties)
@@ -1073,6 +1092,7 @@ public enum Environment
 		this.groundFogOpacity = properties.groundFogOpacity;
 		this.lightPitch = properties.lightPitch;
 		this.lightYaw = properties.lightYaw;
+		this.allowSkyOverride = properties.allowSkyOverride;
 	}
 
 	private static float[] rgb(int r, int g, int b)

--- a/src/main/java/rs117/hd/environments/EnvironmentManager.java
+++ b/src/main/java/rs117/hd/environments/EnvironmentManager.java
@@ -223,10 +223,9 @@ public class EnvironmentManager
 		// If menu and environment overrides are active, set skybox to selected color. Otherwise, set to environment color
 		if(config.overrideSky() && currentEnvironment.isAllowSkyOverride())
 		{
-			DefaultSkyColor defaultSkyColor = config.defaultSkyColor();
-			if (defaultSkyColor != DefaultSkyColor.DEFAULT)
+			if (lastSkyColor != DefaultSkyColor.DEFAULT)
 			{
-				targetFogColor = new float[]{defaultSkyColor.getR() / 255f, defaultSkyColor.getG() / 255f, defaultSkyColor.getB() / 255f};
+				targetFogColor = new float[]{lastSkyColor.getR() / 255f, lastSkyColor.getG() / 255f, lastSkyColor.getB() / 255f};
 			}
 		}
 		else

--- a/src/main/java/rs117/hd/environments/EnvironmentManager.java
+++ b/src/main/java/rs117/hd/environments/EnvironmentManager.java
@@ -219,6 +219,20 @@ public class EnvironmentManager
 		lastFrameTime = System.currentTimeMillis();
 		lastSkyColor = config.defaultSkyColor();
 		lastEnvironmentLighting = config.atmosphericLighting();
+
+		// If menu and environment overrides are active, set skybox to selected color. Otherwise, set to environment color
+		if(config.overrideSky() && currentEnvironment.isAllowSkyOverride())
+		{
+			DefaultSkyColor defaultSkyColor = config.defaultSkyColor();
+			if (defaultSkyColor != DefaultSkyColor.DEFAULT)
+			{
+				targetFogColor = new float[]{defaultSkyColor.getR() / 255f, defaultSkyColor.getG() / 255f, defaultSkyColor.getB() / 255f};
+			}
+		}
+		else
+		{
+			changeEnvironment(currentEnvironment, camTargetX, camTargetY, true);
+		}
 	}
 
 	/**

--- a/src/main/java/rs117/hd/environments/EnvironmentManager.java
+++ b/src/main/java/rs117/hd/environments/EnvironmentManager.java
@@ -71,6 +71,7 @@ public class EnvironmentManager
 	// used for tracking changes to settings
 	DefaultSkyColor lastSkyColor = DefaultSkyColor.DEFAULT;
 	boolean lastEnvironmentLighting = true;
+	boolean lastSkyOverride = false;
 
 	// previous camera target world X
 	private int prevCamTargetX = 0;
@@ -164,7 +165,7 @@ public class EnvironmentManager
 			}
 		}
 
-		if (lastSkyColor != config.defaultSkyColor() || lastEnvironmentLighting != config.atmosphericLighting())
+		if (lastSkyColor != config.defaultSkyColor() || lastEnvironmentLighting != config.atmosphericLighting() || lastSkyOverride != config.overrideSky())
 		{
 			changeEnvironment(currentEnvironment, camTargetX, camTargetY, true);
 		}
@@ -218,20 +219,8 @@ public class EnvironmentManager
 		prevCamTargetY = camTargetY;
 		lastFrameTime = System.currentTimeMillis();
 		lastSkyColor = config.defaultSkyColor();
+		lastSkyOverride = config.overrideSky();
 		lastEnvironmentLighting = config.atmosphericLighting();
-
-		// If menu and environment overrides are active, set skybox to selected color. Otherwise, set to environment color
-		if(config.overrideSky() && currentEnvironment.isAllowSkyOverride())
-		{
-			if (lastSkyColor != DefaultSkyColor.DEFAULT)
-			{
-				targetFogColor = new float[]{lastSkyColor.getR() / 255f, lastSkyColor.getG() / 255f, lastSkyColor.getB() / 255f};
-			}
-		}
-		else
-		{
-			changeEnvironment(currentEnvironment, camTargetX, camTargetY, true);
-		}
 	}
 
 	/**
@@ -284,6 +273,12 @@ public class EnvironmentManager
 				}
 			}
 		}
+
+		// If configured and the environment allows it override the skybox color to the default sky color.
+		if (config.overrideSky() && newEnvironment.isAllowSkyOverride()) {
+			targetFogColor = new float[]{ config.defaultSkyColor().getR() / 255f, config.defaultSkyColor().getG() / 255f, config.defaultSkyColor().getB() / 255f };
+		}
+
 		targetFogDepth = newEnvironment.getFogDepth();
 		if (hdPlugin.configWinterTheme)
 		{

--- a/src/main/resources/rs117/hd/lighting/lights.json
+++ b/src/main/resources/rs117/hd/lighting/lights.json
@@ -19504,10 +19504,10 @@
   },
   {
     "description": "ABHORRENT_SPECTRE",
-    "height": 200,
+    "height": 220,
     "alignment": "CENTER",
-    "radius": 1000,
-    "strength": 25.0,
+    "radius": 900,
+    "strength": 18.0,
     "color": [
       0.59,
       1.0,
@@ -19522,13 +19522,13 @@
   },
   {
     "description": "REPUGNANT_SPECTRE",
-    "height": 200,
+    "height": 220,
     "alignment": "CENTER",
-    "radius": 1000,
-    "strength": 25.0,
+    "radius": 900,
+    "strength": 18.0,
     "color": [
       1.0,
-      0.09,
+      0.0,
       1.0
     ],
     "type": "FLICKER",

--- a/src/main/resources/rs117/hd/lighting/lights.json
+++ b/src/main/resources/rs117/hd/lighting/lights.json
@@ -19504,10 +19504,10 @@
   },
   {
     "description": "ABHORRENT_SPECTRE",
-    "height": 220,
+    "height": 200,
     "alignment": "CENTER",
-    "radius": 900,
-    "strength": 18.0,
+    "radius": 1000,
+    "strength": 25.0,
     "color": [
       0.59,
       1.0,
@@ -19522,13 +19522,13 @@
   },
   {
     "description": "REPUGNANT_SPECTRE",
-    "height": 220,
+    "height": 200,
     "alignment": "CENTER",
-    "radius": 900,
-    "strength": 18.0,
+    "radius": 1000,
+    "strength": 25.0,
     "color": [
       1.0,
-      0.0,
+      0.09,
       1.0
     ],
     "type": "FLICKER",


### PR DESCRIPTION
Currently the environments force specific skybox colors if they are defined, overriding the menu option. This PR adds a checkbox to force the color selected in the menu instead.

It is selectively applied so that areas which need a specific skybox for game or quest design (such as black for empty space at the cosmic altar) can still force their values, but the vast majority of the game world will obey the menu if enabled.

Fixes #205 