### PR TITLE
Switch to using the more intuitive gamma color space for configuring lights

### DIFF
--- a/src/main/java/rs117/hd/lighting/Light.java
+++ b/src/main/java/rs117/hd/lighting/Light.java
@@ -26,6 +26,9 @@ public class Light
 	public Alignment alignment;
 	public int radius;
 	public float strength;
+	/**
+	 * Linear color space RGBA in the range [0, 1]
+	 */
 	public float[] color;
 	public LightType type;
 	public float duration;

--- a/src/main/java/rs117/hd/lighting/LightConfig.java
+++ b/src/main/java/rs117/hd/lighting/LightConfig.java
@@ -13,6 +13,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import lombok.extern.slf4j.Slf4j;
+import rs117.hd.HDUtils;
 
 @Slf4j
 public class LightConfig
@@ -67,6 +68,15 @@ public class LightConfig
 
 			for (Light l : lights)
 			{
+				// Map values from [0, 255] in gamma color space to [0, 1] in linear color space
+				// Also ensure that each color always has 4 components with sensible defaults
+				float[] linearRGBA = { 0, 0, 0, 1 };
+				for (int i = 0; i < Math.min(l.color.length, linearRGBA.length); i++)
+				{
+					linearRGBA[i] = HDUtils.gammaToLinear(l.color[i] /= 255f);
+				}
+				l.color = linearRGBA;
+
 				if (l.worldX != null && l.worldY != null)
 				{
 					worldLights.add(new SceneLight(l));

--- a/src/main/java/rs117/hd/lighting/SceneLight.java
+++ b/src/main/java/rs117/hd/lighting/SceneLight.java
@@ -14,6 +14,9 @@ public class SceneLight extends Light
 
 	public int currentSize;
 	public float currentStrength;
+	/**
+	 * Linear color space RGBA in the range [0, 1]
+	 */
 	public float[] currentColor;
 	public float currentAnimation = 0.5f;
 	public int currentFadeIn = 0;

--- a/src/main/resources/rs117/hd/lighting/lights.json
+++ b/src/main/resources/rs117/hd/lighting/lights.json
@@ -7,15 +7,15 @@
     "height": 20,
     "alignment": "CENTER",
     "radius": 800,
-    "strength": 30.0,
+    "strength": 30,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -26,15 +26,15 @@
     "height": 20,
     "alignment": "CENTER",
     "radius": 800,
-    "strength": 30.0,
+    "strength": 30,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -45,15 +45,15 @@
     "height": 20,
     "alignment": "CENTER",
     "radius": 800,
-    "strength": 30.0,
+    "strength": 30,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -64,15 +64,15 @@
     "height": 20,
     "alignment": "CENTER",
     "radius": 800,
-    "strength": 30.0,
+    "strength": 30,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -83,15 +83,15 @@
     "height": 20,
     "alignment": "CENTER",
     "radius": 800,
-    "strength": 30.0,
+    "strength": 30,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -102,15 +102,15 @@
     "height": 20,
     "alignment": "CENTER",
     "radius": 800,
-    "strength": 30.0,
+    "strength": 30,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -121,15 +121,15 @@
     "height": 20,
     "alignment": "CENTER",
     "radius": 800,
-    "strength": 30.0,
+    "strength": 30,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -140,15 +140,15 @@
     "height": 20,
     "alignment": "CENTER",
     "radius": 800,
-    "strength": 30.0,
+    "strength": 30,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -159,15 +159,15 @@
     "height": 20,
     "alignment": "CENTER",
     "radius": 800,
-    "strength": 30.0,
+    "strength": 30,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -178,15 +178,15 @@
     "height": 20,
     "alignment": "CENTER",
     "radius": 800,
-    "strength": 30.0,
+    "strength": 30,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -197,15 +197,15 @@
     "height": 20,
     "alignment": "CENTER",
     "radius": 800,
-    "strength": 30.0,
+    "strength": 30,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -216,15 +216,15 @@
     "height": 20,
     "alignment": "CENTER",
     "radius": 800,
-    "strength": 30.0,
+    "strength": 30,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -235,15 +235,15 @@
     "height": 20,
     "alignment": "CENTER",
     "radius": 800,
-    "strength": 30.0,
+    "strength": 30,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -254,15 +254,15 @@
     "height": 20,
     "alignment": "CENTER",
     "radius": 800,
-    "strength": 30.0,
+    "strength": 30,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -273,15 +273,15 @@
     "height": 20,
     "alignment": "CENTER",
     "radius": 800,
-    "strength": 30.0,
+    "strength": 30,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -292,15 +292,15 @@
     "height": 20,
     "alignment": "CENTER",
     "radius": 800,
-    "strength": 30.0,
+    "strength": 30,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -311,15 +311,15 @@
     "height": 20,
     "alignment": "CENTER",
     "radius": 800,
-    "strength": 30.0,
+    "strength": 30,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -330,15 +330,15 @@
     "height": 20,
     "alignment": "CENTER",
     "radius": 800,
-    "strength": 30.0,
+    "strength": 30,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -349,15 +349,15 @@
     "height": 20,
     "alignment": "CENTER",
     "radius": 800,
-    "strength": 30.0,
+    "strength": 30,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -368,15 +368,15 @@
     "height": 20,
     "alignment": "CENTER",
     "radius": 800,
-    "strength": 30.0,
+    "strength": 30,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -387,15 +387,15 @@
     "height": 20,
     "alignment": "CENTER",
     "radius": 800,
-    "strength": 30.0,
+    "strength": 30,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -406,15 +406,15 @@
     "height": 20,
     "alignment": "CENTER",
     "radius": 800,
-    "strength": 30.0,
+    "strength": 30,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -425,15 +425,15 @@
     "height": 20,
     "alignment": "CENTER",
     "radius": 800,
-    "strength": 30.0,
+    "strength": 30,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -444,15 +444,15 @@
     "height": 20,
     "alignment": "CENTER",
     "radius": 800,
-    "strength": 30.0,
+    "strength": 30,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -463,15 +463,15 @@
     "height": 20,
     "alignment": "CENTER",
     "radius": 800,
-    "strength": 30.0,
+    "strength": 30,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -482,15 +482,15 @@
     "height": 20,
     "alignment": "CENTER",
     "radius": 800,
-    "strength": 30.0,
+    "strength": 30,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -501,15 +501,15 @@
     "height": 20,
     "alignment": "CENTER",
     "radius": 800,
-    "strength": 30.0,
+    "strength": 30,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -520,15 +520,15 @@
     "height": 20,
     "alignment": "CENTER",
     "radius": 800,
-    "strength": 30.0,
+    "strength": 30,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -539,15 +539,15 @@
     "height": 20,
     "alignment": "CENTER",
     "radius": 800,
-    "strength": 30.0,
+    "strength": 30,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -558,15 +558,15 @@
     "height": 20,
     "alignment": "CENTER",
     "radius": 800,
-    "strength": 30.0,
+    "strength": 30,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -577,15 +577,15 @@
     "height": 20,
     "alignment": "CENTER",
     "radius": 800,
-    "strength": 30.0,
+    "strength": 30,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -596,15 +596,15 @@
     "height": 20,
     "alignment": "CENTER",
     "radius": 800,
-    "strength": 30.0,
+    "strength": 30,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -615,15 +615,15 @@
     "height": 20,
     "alignment": "CENTER",
     "radius": 800,
-    "strength": 30.0,
+    "strength": 30,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -634,15 +634,15 @@
     "height": 20,
     "alignment": "CENTER",
     "radius": 800,
-    "strength": 30.0,
+    "strength": 30,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -653,15 +653,15 @@
     "height": 20,
     "alignment": "CENTER",
     "radius": 800,
-    "strength": 30.0,
+    "strength": 30,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -672,15 +672,15 @@
     "height": 20,
     "alignment": "CENTER",
     "radius": 800,
-    "strength": 30.0,
+    "strength": 30,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -691,15 +691,15 @@
     "height": 20,
     "alignment": "CENTER",
     "radius": 800,
-    "strength": 30.0,
+    "strength": 30,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -710,15 +710,15 @@
     "height": 20,
     "alignment": "CENTER",
     "radius": 800,
-    "strength": 30.0,
+    "strength": 30,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -729,15 +729,15 @@
     "height": 20,
     "alignment": "CENTER",
     "radius": 800,
-    "strength": 30.0,
+    "strength": 30,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -748,15 +748,15 @@
     "height": 20,
     "alignment": "CENTER",
     "radius": 800,
-    "strength": 30.0,
+    "strength": 30,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -767,15 +767,15 @@
     "height": 20,
     "alignment": "CENTER",
     "radius": 800,
-    "strength": 30.0,
+    "strength": 30,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -786,15 +786,15 @@
     "height": 20,
     "alignment": "CENTER",
     "radius": 800,
-    "strength": 30.0,
+    "strength": 30,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -805,15 +805,15 @@
     "height": 20,
     "alignment": "CENTER",
     "radius": 800,
-    "strength": 30.0,
+    "strength": 30,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -824,15 +824,15 @@
     "height": 20,
     "alignment": "CENTER",
     "radius": 800,
-    "strength": 30.0,
+    "strength": 30,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -843,15 +843,15 @@
     "height": 20,
     "alignment": "CENTER",
     "radius": 800,
-    "strength": 30.0,
+    "strength": 30,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -862,15 +862,15 @@
     "height": 20,
     "alignment": "CENTER",
     "radius": 800,
-    "strength": 30.0,
+    "strength": 30,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -881,15 +881,15 @@
     "height": 20,
     "alignment": "CENTER",
     "radius": 800,
-    "strength": 30.0,
+    "strength": 30,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -900,15 +900,15 @@
     "height": 20,
     "alignment": "CENTER",
     "radius": 800,
-    "strength": 30.0,
+    "strength": 30,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -919,15 +919,15 @@
     "height": 20,
     "alignment": "CENTER",
     "radius": 800,
-    "strength": 30.0,
+    "strength": 30,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -938,15 +938,15 @@
     "height": 20,
     "alignment": "CENTER",
     "radius": 800,
-    "strength": 30.0,
+    "strength": 30,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -957,15 +957,15 @@
     "height": 20,
     "alignment": "CENTER",
     "radius": 800,
-    "strength": 30.0,
+    "strength": 30,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -976,15 +976,15 @@
     "height": 20,
     "alignment": "CENTER",
     "radius": 800,
-    "strength": 30.0,
+    "strength": 30,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -995,15 +995,15 @@
     "height": 20,
     "alignment": "CENTER",
     "radius": 800,
-    "strength": 30.0,
+    "strength": 30,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -1014,15 +1014,15 @@
     "height": 20,
     "alignment": "CENTER",
     "radius": 800,
-    "strength": 30.0,
+    "strength": 30,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -1033,15 +1033,15 @@
     "height": 20,
     "alignment": "CENTER",
     "radius": 800,
-    "strength": 30.0,
+    "strength": 30,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -1052,15 +1052,15 @@
     "height": 20,
     "alignment": "CENTER",
     "radius": 800,
-    "strength": 30.0,
+    "strength": 30,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -1071,15 +1071,15 @@
     "height": 20,
     "alignment": "CENTER",
     "radius": 800,
-    "strength": 30.0,
+    "strength": 30,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -1090,15 +1090,15 @@
     "height": 20,
     "alignment": "CENTER",
     "radius": 800,
-    "strength": 30.0,
+    "strength": 30,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -1109,15 +1109,15 @@
     "height": 20,
     "alignment": "CENTER",
     "radius": 800,
-    "strength": 30.0,
+    "strength": 30,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -1128,15 +1128,15 @@
     "height": 20,
     "alignment": "CENTER",
     "radius": 800,
-    "strength": 30.0,
+    "strength": 30,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -1147,15 +1147,15 @@
     "height": 20,
     "alignment": "CENTER",
     "radius": 800,
-    "strength": 30.0,
+    "strength": 30,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -1166,15 +1166,15 @@
     "height": 20,
     "alignment": "CENTER",
     "radius": 800,
-    "strength": 30.0,
+    "strength": 30,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -1185,15 +1185,15 @@
     "height": 20,
     "alignment": "CENTER",
     "radius": 800,
-    "strength": 30.0,
+    "strength": 30,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -1204,15 +1204,15 @@
     "height": 20,
     "alignment": "CENTER",
     "radius": 800,
-    "strength": 30.0,
+    "strength": 30,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -1223,15 +1223,15 @@
     "height": 20,
     "alignment": "CENTER",
     "radius": 800,
-    "strength": 30.0,
+    "strength": 30,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -1242,15 +1242,15 @@
     "height": 20,
     "alignment": "CENTER",
     "radius": 800,
-    "strength": 30.0,
+    "strength": 30,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -1261,15 +1261,15 @@
     "height": 20,
     "alignment": "CENTER",
     "radius": 800,
-    "strength": 30.0,
+    "strength": 30,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -1280,15 +1280,15 @@
     "height": 20,
     "alignment": "CENTER",
     "radius": 800,
-    "strength": 30.0,
+    "strength": 30,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -1299,15 +1299,15 @@
     "height": 20,
     "alignment": "CENTER",
     "radius": 800,
-    "strength": 30.0,
+    "strength": 30,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -1318,15 +1318,15 @@
     "height": 20,
     "alignment": "CENTER",
     "radius": 800,
-    "strength": 30.0,
+    "strength": 30,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -1337,15 +1337,15 @@
     "height": 20,
     "alignment": "CENTER",
     "radius": 800,
-    "strength": 30.0,
+    "strength": 30,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -1356,15 +1356,15 @@
     "height": 20,
     "alignment": "CENTER",
     "radius": 800,
-    "strength": 30.0,
+    "strength": 30,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -1375,15 +1375,15 @@
     "height": 20,
     "alignment": "CENTER",
     "radius": 800,
-    "strength": 30.0,
+    "strength": 30,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -1394,15 +1394,15 @@
     "height": 20,
     "alignment": "CENTER",
     "radius": 800,
-    "strength": 30.0,
+    "strength": 30,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -1413,15 +1413,15 @@
     "height": 20,
     "alignment": "CENTER",
     "radius": 800,
-    "strength": 30.0,
+    "strength": 30,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -1432,15 +1432,15 @@
     "height": 20,
     "alignment": "CENTER",
     "radius": 800,
-    "strength": 30.0,
+    "strength": 30,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -1451,15 +1451,15 @@
     "height": 20,
     "alignment": "CENTER",
     "radius": 800,
-    "strength": 30.0,
+    "strength": 30,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -1470,15 +1470,15 @@
     "height": 20,
     "alignment": "CENTER",
     "radius": 800,
-    "strength": 30.0,
+    "strength": 30,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -1489,15 +1489,15 @@
     "height": 20,
     "alignment": "CENTER",
     "radius": 800,
-    "strength": 30.0,
+    "strength": 30,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -1508,15 +1508,15 @@
     "height": -20,
     "alignment": "CENTER",
     "radius": 600,
-    "strength": 35.0,
+    "strength": 35,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -1527,15 +1527,15 @@
     "height": -20,
     "alignment": "CENTER",
     "radius": 600,
-    "strength": 35.0,
+    "strength": 35,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -1546,15 +1546,15 @@
     "height": -20,
     "alignment": "CENTER",
     "radius": 600,
-    "strength": 35.0,
+    "strength": 35,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -1565,15 +1565,15 @@
     "height": -20,
     "alignment": "CENTER",
     "radius": 600,
-    "strength": 35.0,
+    "strength": 35,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -1584,15 +1584,15 @@
     "height": -20,
     "alignment": "CENTER",
     "radius": 600,
-    "strength": 35.0,
+    "strength": 35,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -1603,15 +1603,15 @@
     "height": -20,
     "alignment": "CENTER",
     "radius": 600,
-    "strength": 35.0,
+    "strength": 35,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -1622,15 +1622,15 @@
     "height": -20,
     "alignment": "CENTER",
     "radius": 600,
-    "strength": 35.0,
+    "strength": 35,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -1641,15 +1641,15 @@
     "height": -20,
     "alignment": "CENTER",
     "radius": 600,
-    "strength": 35.0,
+    "strength": 35,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -1660,15 +1660,15 @@
     "height": -20,
     "alignment": "CENTER",
     "radius": 600,
-    "strength": 35.0,
+    "strength": 35,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -1679,15 +1679,15 @@
     "height": -20,
     "alignment": "CENTER",
     "radius": 600,
-    "strength": 35.0,
+    "strength": 35,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -1698,15 +1698,15 @@
     "height": -20,
     "alignment": "CENTER",
     "radius": 600,
-    "strength": 35.0,
+    "strength": 35,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -1717,15 +1717,15 @@
     "height": -20,
     "alignment": "CENTER",
     "radius": 600,
-    "strength": 35.0,
+    "strength": 35,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -1736,15 +1736,15 @@
     "height": -20,
     "alignment": "CENTER",
     "radius": 600,
-    "strength": 35.0,
+    "strength": 35,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -1755,15 +1755,15 @@
     "height": -20,
     "alignment": "CENTER",
     "radius": 600,
-    "strength": 35.0,
+    "strength": 35,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -1774,15 +1774,15 @@
     "height": -20,
     "alignment": "CENTER",
     "radius": 600,
-    "strength": 35.0,
+    "strength": 35,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -1793,15 +1793,15 @@
     "height": -20,
     "alignment": "CENTER",
     "radius": 600,
-    "strength": 35.0,
+    "strength": 35,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -1812,15 +1812,15 @@
     "height": -20,
     "alignment": "CENTER",
     "radius": 600,
-    "strength": 35.0,
+    "strength": 35,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -1831,15 +1831,15 @@
     "height": -20,
     "alignment": "CENTER",
     "radius": 600,
-    "strength": 35.0,
+    "strength": 35,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -1850,15 +1850,15 @@
     "height": -20,
     "alignment": "CENTER",
     "radius": 600,
-    "strength": 35.0,
+    "strength": 35,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -1869,15 +1869,15 @@
     "height": -20,
     "alignment": "CENTER",
     "radius": 600,
-    "strength": 35.0,
+    "strength": 35,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -1888,15 +1888,15 @@
     "height": -20,
     "alignment": "CENTER",
     "radius": 600,
-    "strength": 35.0,
+    "strength": 35,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -1907,15 +1907,15 @@
     "height": -20,
     "alignment": "CENTER",
     "radius": 600,
-    "strength": 35.0,
+    "strength": 35,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -1926,15 +1926,15 @@
     "height": -20,
     "alignment": "CENTER",
     "radius": 600,
-    "strength": 35.0,
+    "strength": 35,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -1945,15 +1945,15 @@
     "height": -20,
     "alignment": "CENTER",
     "radius": 600,
-    "strength": 35.0,
+    "strength": 35,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -1964,15 +1964,15 @@
     "height": -20,
     "alignment": "CENTER",
     "radius": 600,
-    "strength": 35.0,
+    "strength": 35,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -1983,15 +1983,15 @@
     "height": -20,
     "alignment": "CENTER",
     "radius": 600,
-    "strength": 35.0,
+    "strength": 35,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -2002,15 +2002,15 @@
     "height": -20,
     "alignment": "CENTER",
     "radius": 600,
-    "strength": 35.0,
+    "strength": 35,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -2021,15 +2021,15 @@
     "height": -20,
     "alignment": "CENTER",
     "radius": 600,
-    "strength": 35.0,
+    "strength": 35,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -2040,15 +2040,15 @@
     "height": -20,
     "alignment": "CENTER",
     "radius": 600,
-    "strength": 35.0,
+    "strength": 35,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -2059,15 +2059,15 @@
     "height": -20,
     "alignment": "CENTER",
     "radius": 600,
-    "strength": 35.0,
+    "strength": 35,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -2078,15 +2078,15 @@
     "height": -20,
     "alignment": "CENTER",
     "radius": 600,
-    "strength": 35.0,
+    "strength": 35,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -2097,15 +2097,15 @@
     "height": -20,
     "alignment": "CENTER",
     "radius": 600,
-    "strength": 35.0,
+    "strength": 35,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -2116,15 +2116,15 @@
     "height": -20,
     "alignment": "CENTER",
     "radius": 600,
-    "strength": 35.0,
+    "strength": 35,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -2137,13 +2137,13 @@
     "radius": 2200,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -2156,13 +2156,13 @@
     "radius": 2200,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -2175,13 +2175,13 @@
     "radius": 2200,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -2194,13 +2194,13 @@
     "radius": 2200,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -2213,13 +2213,13 @@
     "radius": 2200,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -2232,13 +2232,13 @@
     "radius": 2200,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -2251,13 +2251,13 @@
     "radius": 2200,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -2270,13 +2270,13 @@
     "radius": 2200,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -2289,13 +2289,13 @@
     "radius": 2200,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -2308,13 +2308,13 @@
     "radius": 2200,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -2327,13 +2327,13 @@
     "radius": 2200,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -2346,13 +2346,13 @@
     "radius": 2200,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -2365,13 +2365,13 @@
     "radius": 2200,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -2384,13 +2384,13 @@
     "radius": 2200,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -2403,13 +2403,13 @@
     "radius": 2200,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -2422,13 +2422,13 @@
     "radius": 2200,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -2441,13 +2441,13 @@
     "radius": 2200,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -2460,13 +2460,13 @@
     "radius": 2200,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -2479,13 +2479,13 @@
     "radius": 2200,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -2498,13 +2498,13 @@
     "radius": 2200,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -2517,13 +2517,13 @@
     "radius": 2200,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -2536,13 +2536,13 @@
     "radius": 2200,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -2555,13 +2555,13 @@
     "radius": 2200,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -2574,13 +2574,13 @@
     "radius": 2200,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -2593,13 +2593,13 @@
     "radius": 2200,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -2612,13 +2612,13 @@
     "radius": 2200,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -2631,13 +2631,13 @@
     "radius": 2200,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -2650,13 +2650,13 @@
     "radius": 2200,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -2669,13 +2669,13 @@
     "radius": 2200,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -2688,13 +2688,13 @@
     "radius": 2200,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -2707,13 +2707,13 @@
     "radius": 2200,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -2726,13 +2726,13 @@
     "radius": 2200,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -2745,13 +2745,13 @@
     "radius": 2200,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -2764,13 +2764,13 @@
     "radius": 2200,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -2783,13 +2783,13 @@
     "radius": 2200,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -2802,13 +2802,13 @@
     "radius": 2200,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -2819,15 +2819,15 @@
     "height": 50,
     "alignment": "CENTER",
     "radius": 2000,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -2838,15 +2838,15 @@
     "height": 50,
     "alignment": "CENTER",
     "radius": 2000,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -2857,15 +2857,15 @@
     "height": 50,
     "alignment": "CENTER",
     "radius": 2000,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -2876,15 +2876,15 @@
     "height": 50,
     "alignment": "CENTER",
     "radius": 2000,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -2895,15 +2895,15 @@
     "height": 50,
     "alignment": "CENTER",
     "radius": 2000,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -2914,15 +2914,15 @@
     "height": 50,
     "alignment": "CENTER",
     "radius": 2000,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -2933,15 +2933,15 @@
     "height": 50,
     "alignment": "CENTER",
     "radius": 2000,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -2952,15 +2952,15 @@
     "height": 50,
     "alignment": "CENTER",
     "radius": 2000,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -2971,15 +2971,15 @@
     "height": 50,
     "alignment": "CENTER",
     "radius": 2000,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -2990,15 +2990,15 @@
     "height": 50,
     "alignment": "CENTER",
     "radius": 2000,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -3009,15 +3009,15 @@
     "height": 50,
     "alignment": "CENTER",
     "radius": 2000,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -3028,15 +3028,15 @@
     "height": 50,
     "alignment": "CENTER",
     "radius": 2000,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -3047,15 +3047,15 @@
     "height": 50,
     "alignment": "CENTER",
     "radius": 2000,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -3066,15 +3066,15 @@
     "height": 50,
     "alignment": "CENTER",
     "radius": 2000,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -3085,15 +3085,15 @@
     "height": 50,
     "alignment": "CENTER",
     "radius": 2000,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -3104,15 +3104,15 @@
     "height": 50,
     "alignment": "CENTER",
     "radius": 2000,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -3123,15 +3123,15 @@
     "height": 50,
     "alignment": "CENTER",
     "radius": 2000,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -3142,15 +3142,15 @@
     "height": 50,
     "alignment": "CENTER",
     "radius": 1500,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -3161,15 +3161,15 @@
     "height": 50,
     "alignment": "CENTER",
     "radius": 1500,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -3180,15 +3180,15 @@
     "height": 50,
     "alignment": "CENTER",
     "radius": 1500,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -3199,15 +3199,15 @@
     "height": 50,
     "alignment": "CENTER",
     "radius": 1500,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -3218,15 +3218,15 @@
     "height": 50,
     "alignment": "CENTER",
     "radius": 1500,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -3237,15 +3237,15 @@
     "height": 50,
     "alignment": "CENTER",
     "radius": 1500,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -3256,15 +3256,15 @@
     "height": 50,
     "alignment": "CENTER",
     "radius": 1500,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -3277,13 +3277,13 @@
     "radius": 2000,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 25.0,
+    "duration": 3000,
+    "range": 25,
     "fadeInDuration": 0
   },
   {
@@ -3296,13 +3296,13 @@
     "radius": 2000,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 25.0,
+    "duration": 3000,
+    "range": 25,
     "fadeInDuration": 0
   },
   {
@@ -3315,13 +3315,13 @@
     "radius": 2000,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 25.0,
+    "duration": 3000,
+    "range": 25,
     "fadeInDuration": 0
   },
   {
@@ -3334,13 +3334,13 @@
     "radius": 2000,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 25.0,
+    "duration": 3000,
+    "range": 25,
     "fadeInDuration": 0
   },
   {
@@ -3353,13 +3353,13 @@
     "radius": 2000,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 25.0,
+    "duration": 3000,
+    "range": 25,
     "fadeInDuration": 0
   },
   {
@@ -3372,13 +3372,13 @@
     "radius": 2000,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 25.0,
+    "duration": 3000,
+    "range": 25,
     "fadeInDuration": 0
   },
   {
@@ -3391,13 +3391,13 @@
     "radius": 2000,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 25.0,
+    "duration": 3000,
+    "range": 25,
     "fadeInDuration": 0
   },
   {
@@ -3410,13 +3410,13 @@
     "radius": 2000,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 25.0,
+    "duration": 3000,
+    "range": 25,
     "fadeInDuration": 0
   },
   {
@@ -3429,13 +3429,13 @@
     "radius": 2000,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 25.0,
+    "duration": 3000,
+    "range": 25,
     "fadeInDuration": 0
   },
   {
@@ -3448,13 +3448,13 @@
     "radius": 2000,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 25.0,
+    "duration": 3000,
+    "range": 25,
     "fadeInDuration": 0
   },
   {
@@ -3467,13 +3467,13 @@
     "radius": 2000,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 25.0,
+    "duration": 3000,
+    "range": 25,
     "fadeInDuration": 0
   },
   {
@@ -3486,13 +3486,13 @@
     "radius": 2000,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 25.0,
+    "duration": 3000,
+    "range": 25,
     "fadeInDuration": 0
   },
   {
@@ -3505,13 +3505,13 @@
     "radius": 2000,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 25.0,
+    "duration": 3000,
+    "range": 25,
     "fadeInDuration": 0
   },
   {
@@ -3524,13 +3524,13 @@
     "radius": 2000,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 25.0,
+    "duration": 3000,
+    "range": 25,
     "fadeInDuration": 0
   },
   {
@@ -3543,13 +3543,13 @@
     "radius": 2000,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 25.0,
+    "duration": 3000,
+    "range": 25,
     "fadeInDuration": 0
   },
   {
@@ -3562,13 +3562,13 @@
     "radius": 2000,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 25.0,
+    "duration": 3000,
+    "range": 25,
     "fadeInDuration": 0
   },
   {
@@ -3581,13 +3581,13 @@
     "radius": 2000,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 25.0,
+    "duration": 3000,
+    "range": 25,
     "fadeInDuration": 0
   },
   {
@@ -3600,13 +3600,13 @@
     "radius": 2000,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 25.0,
+    "duration": 3000,
+    "range": 25,
     "fadeInDuration": 0
   },
   {
@@ -3619,13 +3619,13 @@
     "radius": 2000,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 25.0,
+    "duration": 3000,
+    "range": 25,
     "fadeInDuration": 0
   },
   {
@@ -3638,13 +3638,13 @@
     "radius": 2000,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 25.0,
+    "duration": 3000,
+    "range": 25,
     "fadeInDuration": 0
   },
   {
@@ -3657,13 +3657,13 @@
     "radius": 2000,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 25.0,
+    "duration": 3000,
+    "range": 25,
     "fadeInDuration": 0
   },
   {
@@ -3676,13 +3676,13 @@
     "radius": 2000,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 25.0,
+    "duration": 3000,
+    "range": 25,
     "fadeInDuration": 0
   },
   {
@@ -3695,13 +3695,13 @@
     "radius": 2000,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 25.0,
+    "duration": 3000,
+    "range": 25,
     "fadeInDuration": 0
   },
   {
@@ -3714,13 +3714,13 @@
     "radius": 2000,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 25.0,
+    "duration": 3000,
+    "range": 25,
     "fadeInDuration": 0
   },
   {
@@ -3733,13 +3733,13 @@
     "radius": 2000,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 25.0,
+    "duration": 3000,
+    "range": 25,
     "fadeInDuration": 0
   },
   {
@@ -3752,13 +3752,13 @@
     "radius": 2000,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 25.0,
+    "duration": 3000,
+    "range": 25,
     "fadeInDuration": 0
   },
   {
@@ -3771,13 +3771,13 @@
     "radius": 2000,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 25.0,
+    "duration": 3000,
+    "range": 25,
     "fadeInDuration": 0
   },
   {
@@ -3790,13 +3790,13 @@
     "radius": 2000,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 25.0,
+    "duration": 3000,
+    "range": 25,
     "fadeInDuration": 0
   },
   {
@@ -3809,13 +3809,13 @@
     "radius": 2000,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 25.0,
+    "duration": 3000,
+    "range": 25,
     "fadeInDuration": 0
   },
   {
@@ -3828,13 +3828,13 @@
     "radius": 2000,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 25.0,
+    "duration": 3000,
+    "range": 25,
     "fadeInDuration": 0
   },
   {
@@ -3847,13 +3847,13 @@
     "radius": 2000,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 25.0,
+    "duration": 3000,
+    "range": 25,
     "fadeInDuration": 0
   },
   {
@@ -3866,13 +3866,13 @@
     "radius": 2000,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 25.0,
+    "duration": 3000,
+    "range": 25,
     "fadeInDuration": 0
   },
   {
@@ -3885,13 +3885,13 @@
     "radius": 2000,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 25.0,
+    "duration": 3000,
+    "range": 25,
     "fadeInDuration": 0
   },
   {
@@ -3904,13 +3904,13 @@
     "radius": 2000,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 25.0,
+    "duration": 3000,
+    "range": 25,
     "fadeInDuration": 0
   },
   {
@@ -3923,13 +3923,13 @@
     "radius": 2000,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 25.0,
+    "duration": 3000,
+    "range": 25,
     "fadeInDuration": 0
   },
   {
@@ -3942,13 +3942,13 @@
     "radius": 2000,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 25.0,
+    "duration": 3000,
+    "range": 25,
     "fadeInDuration": 0
   },
   {
@@ -3961,13 +3961,13 @@
     "radius": 2000,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 25.0,
+    "duration": 3000,
+    "range": 25,
     "fadeInDuration": 0
   },
   {
@@ -3980,13 +3980,13 @@
     "radius": 2000,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 25.0,
+    "duration": 3000,
+    "range": 25,
     "fadeInDuration": 0
   },
   {
@@ -3999,13 +3999,13 @@
     "radius": 2000,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 25.0,
+    "duration": 3000,
+    "range": 25,
     "fadeInDuration": 0
   },
   {
@@ -4018,13 +4018,13 @@
     "radius": 2000,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 25.0,
+    "duration": 3000,
+    "range": 25,
     "fadeInDuration": 0
   },
   {
@@ -4037,13 +4037,13 @@
     "radius": 2000,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 25.0,
+    "duration": 3000,
+    "range": 25,
     "fadeInDuration": 0
   },
   {
@@ -4056,13 +4056,13 @@
     "radius": 2000,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 25.0,
+    "duration": 3000,
+    "range": 25,
     "fadeInDuration": 0
   },
   {
@@ -4075,13 +4075,13 @@
     "radius": 2000,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 25.0,
+    "duration": 3000,
+    "range": 25,
     "fadeInDuration": 0
   },
   {
@@ -4094,13 +4094,13 @@
     "radius": 2000,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 25.0,
+    "duration": 3000,
+    "range": 25,
     "fadeInDuration": 0
   },
   {
@@ -4113,13 +4113,13 @@
     "radius": 2000,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 25.0,
+    "duration": 3000,
+    "range": 25,
     "fadeInDuration": 0
   },
   {
@@ -4132,13 +4132,13 @@
     "radius": 2000,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 25.0,
+    "duration": 3000,
+    "range": 25,
     "fadeInDuration": 0
   },
   {
@@ -4151,13 +4151,13 @@
     "radius": 2000,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 25.0,
+    "duration": 3000,
+    "range": 25,
     "fadeInDuration": 0
   },
   {
@@ -4170,13 +4170,13 @@
     "radius": 2000,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 25.0,
+    "duration": 3000,
+    "range": 25,
     "fadeInDuration": 0
   },
   {
@@ -4189,13 +4189,13 @@
     "radius": 2000,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 25.0,
+    "duration": 3000,
+    "range": 25,
     "fadeInDuration": 0
   },
   {
@@ -4208,13 +4208,13 @@
     "radius": 2000,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 25.0,
+    "duration": 3000,
+    "range": 25,
     "fadeInDuration": 0
   },
   {
@@ -4227,13 +4227,13 @@
     "radius": 2000,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 25.0,
+    "duration": 3000,
+    "range": 25,
     "fadeInDuration": 0
   },
   {
@@ -4246,13 +4246,13 @@
     "radius": 2000,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 25.0,
+    "duration": 3000,
+    "range": 25,
     "fadeInDuration": 0
   },
   {
@@ -4265,13 +4265,13 @@
     "radius": 2000,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 25.0,
+    "duration": 3000,
+    "range": 25,
     "fadeInDuration": 0
   },
   {
@@ -4284,13 +4284,13 @@
     "radius": 2000,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 25.0,
+    "duration": 3000,
+    "range": 25,
     "fadeInDuration": 0
   },
   {
@@ -4303,13 +4303,13 @@
     "radius": 2000,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 25.0,
+    "duration": 3000,
+    "range": 25,
     "fadeInDuration": 0
   },
   {
@@ -4322,13 +4322,13 @@
     "radius": 2000,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 25.0,
+    "duration": 3000,
+    "range": 25,
     "fadeInDuration": 0
   },
   {
@@ -4341,13 +4341,13 @@
     "radius": 2000,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 25.0,
+    "duration": 3000,
+    "range": 25,
     "fadeInDuration": 0
   },
   {
@@ -4360,13 +4360,13 @@
     "radius": 2000,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 25.0,
+    "duration": 3000,
+    "range": 25,
     "fadeInDuration": 0
   },
   {
@@ -4379,13 +4379,13 @@
     "radius": 2000,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 25.0,
+    "duration": 3000,
+    "range": 25,
     "fadeInDuration": 0
   },
   {
@@ -4398,13 +4398,13 @@
     "radius": 2000,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 25.0,
+    "duration": 3000,
+    "range": 25,
     "fadeInDuration": 0
   },
   {
@@ -4417,13 +4417,13 @@
     "radius": 2000,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 25.0,
+    "duration": 3000,
+    "range": 25,
     "fadeInDuration": 0
   },
   {
@@ -4436,13 +4436,13 @@
     "radius": 2000,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 25.0,
+    "duration": 3000,
+    "range": 25,
     "fadeInDuration": 0
   },
   {
@@ -4455,13 +4455,13 @@
     "radius": 2000,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 25.0,
+    "duration": 3000,
+    "range": 25,
     "fadeInDuration": 0
   },
   {
@@ -4474,13 +4474,13 @@
     "radius": 2000,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 25.0,
+    "duration": 3000,
+    "range": 25,
     "fadeInDuration": 0
   },
   {
@@ -4493,13 +4493,13 @@
     "radius": 2000,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 25.0,
+    "duration": 3000,
+    "range": 25,
     "fadeInDuration": 0
   },
   {
@@ -4512,13 +4512,13 @@
     "radius": 2000,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 25.0,
+    "duration": 3000,
+    "range": 25,
     "fadeInDuration": 0
   },
   {
@@ -4531,13 +4531,13 @@
     "radius": 2000,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 25.0,
+    "duration": 3000,
+    "range": 25,
     "fadeInDuration": 0
   },
   {
@@ -4550,13 +4550,13 @@
     "radius": 2000,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 25.0,
+    "duration": 3000,
+    "range": 25,
     "fadeInDuration": 0
   },
   {
@@ -4569,13 +4569,13 @@
     "radius": 2000,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 25.0,
+    "duration": 3000,
+    "range": 25,
     "fadeInDuration": 0
   },
   {
@@ -4588,13 +4588,13 @@
     "radius": 2000,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 25.0,
+    "duration": 3000,
+    "range": 25,
     "fadeInDuration": 0
   },
   {
@@ -4607,13 +4607,13 @@
     "radius": 2000,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 25.0,
+    "duration": 3000,
+    "range": 25,
     "fadeInDuration": 0
   },
   {
@@ -4626,13 +4626,13 @@
     "radius": 2000,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 25.0,
+    "duration": 3000,
+    "range": 25,
     "fadeInDuration": 0
   },
   {
@@ -4645,13 +4645,13 @@
     "radius": 2000,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 25.0,
+    "duration": 3000,
+    "range": 25,
     "fadeInDuration": 0
   },
   {
@@ -4664,13 +4664,13 @@
     "radius": 2000,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 25.0,
+    "duration": 3000,
+    "range": 25,
     "fadeInDuration": 0
   },
   {
@@ -4683,13 +4683,13 @@
     "radius": 2000,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 25.0,
+    "duration": 3000,
+    "range": 25,
     "fadeInDuration": 0
   },
   {
@@ -4702,13 +4702,13 @@
     "radius": 2000,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 25.0,
+    "duration": 3000,
+    "range": 25,
     "fadeInDuration": 0
   },
   {
@@ -4721,13 +4721,13 @@
     "radius": 2000,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 25.0,
+    "duration": 3000,
+    "range": 25,
     "fadeInDuration": 0
   },
   {
@@ -4740,13 +4740,13 @@
     "radius": 2000,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 25.0,
+    "duration": 3000,
+    "range": 25,
     "fadeInDuration": 0
   },
   {
@@ -4759,13 +4759,13 @@
     "radius": 2000,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 25.0,
+    "duration": 3000,
+    "range": 25,
     "fadeInDuration": 0
   },
   {
@@ -4778,13 +4778,13 @@
     "radius": 2000,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 25.0,
+    "duration": 3000,
+    "range": 25,
     "fadeInDuration": 0
   },
   {
@@ -4797,13 +4797,13 @@
     "radius": 2000,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 25.0,
+    "duration": 3000,
+    "range": 25,
     "fadeInDuration": 0
   },
   {
@@ -4816,13 +4816,13 @@
     "radius": 2000,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 25.0,
+    "duration": 3000,
+    "range": 25,
     "fadeInDuration": 0
   },
   {
@@ -4835,13 +4835,13 @@
     "radius": 2000,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 25.0,
+    "duration": 3000,
+    "range": 25,
     "fadeInDuration": 0
   },
   {
@@ -4854,13 +4854,13 @@
     "radius": 2000,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 25.0,
+    "duration": 3000,
+    "range": 25,
     "fadeInDuration": 0
   },
   {
@@ -4873,13 +4873,13 @@
     "radius": 2000,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 25.0,
+    "duration": 3000,
+    "range": 25,
     "fadeInDuration": 0
   },
   {
@@ -4892,13 +4892,13 @@
     "radius": 2000,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 25.0,
+    "duration": 3000,
+    "range": 25,
     "fadeInDuration": 0
   },
   {
@@ -4911,13 +4911,13 @@
     "radius": 2000,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 25.0,
+    "duration": 3000,
+    "range": 25,
     "fadeInDuration": 0
   },
   {
@@ -4930,13 +4930,13 @@
     "radius": 2000,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 25.0,
+    "duration": 3000,
+    "range": 25,
     "fadeInDuration": 0
   },
   {
@@ -4949,13 +4949,13 @@
     "radius": 2000,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 25.0,
+    "duration": 3000,
+    "range": 25,
     "fadeInDuration": 0
   },
   {
@@ -4968,13 +4968,13 @@
     "radius": 2000,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 25.0,
+    "duration": 3000,
+    "range": 25,
     "fadeInDuration": 0
   },
   {
@@ -4987,13 +4987,13 @@
     "radius": 2000,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 25.0,
+    "duration": 3000,
+    "range": 25,
     "fadeInDuration": 0
   },
   {
@@ -5006,13 +5006,13 @@
     "radius": 2000,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 25.0,
+    "duration": 3000,
+    "range": 25,
     "fadeInDuration": 0
   },
   {
@@ -5025,13 +5025,13 @@
     "radius": 2000,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 25.0,
+    "duration": 3000,
+    "range": 25,
     "fadeInDuration": 0
   },
   {
@@ -5044,13 +5044,13 @@
     "radius": 2000,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 25.0,
+    "duration": 3000,
+    "range": 25,
     "fadeInDuration": 0
   },
   {
@@ -5063,13 +5063,13 @@
     "radius": 2000,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 25.0,
+    "duration": 3000,
+    "range": 25,
     "fadeInDuration": 0
   },
   {
@@ -5082,13 +5082,13 @@
     "radius": 2000,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 25.0,
+    "duration": 3000,
+    "range": 25,
     "fadeInDuration": 0
   },
   {
@@ -5101,13 +5101,13 @@
     "radius": 2000,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 25.0,
+    "duration": 3000,
+    "range": 25,
     "fadeInDuration": 0
   },
   {
@@ -5120,13 +5120,13 @@
     "radius": 2000,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 25.0,
+    "duration": 3000,
+    "range": 25,
     "fadeInDuration": 0
   },
   {
@@ -5139,13 +5139,13 @@
     "radius": 2000,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 25.0,
+    "duration": 3000,
+    "range": 25,
     "fadeInDuration": 0
   },
   {
@@ -5158,13 +5158,13 @@
     "radius": 2000,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 25.0,
+    "duration": 3000,
+    "range": 25,
     "fadeInDuration": 0
   },
   {
@@ -5177,13 +5177,13 @@
     "radius": 2000,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 25.0,
+    "duration": 3000,
+    "range": 25,
     "fadeInDuration": 0
   },
   {
@@ -5196,13 +5196,13 @@
     "radius": 2000,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 25.0,
+    "duration": 3000,
+    "range": 25,
     "fadeInDuration": 0
   },
   {
@@ -5215,13 +5215,13 @@
     "radius": 2000,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 25.0,
+    "duration": 3000,
+    "range": 25,
     "fadeInDuration": 0
   },
   {
@@ -5234,13 +5234,13 @@
     "radius": 2000,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 25.0,
+    "duration": 3000,
+    "range": 25,
     "fadeInDuration": 0
   },
   {
@@ -5253,13 +5253,13 @@
     "radius": 2000,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 25.0,
+    "duration": 3000,
+    "range": 25,
     "fadeInDuration": 0
   },
   {
@@ -5272,13 +5272,13 @@
     "radius": 2000,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 25.0,
+    "duration": 3000,
+    "range": 25,
     "fadeInDuration": 0
   },
   {
@@ -5291,13 +5291,13 @@
     "radius": 2000,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 25.0,
+    "duration": 3000,
+    "range": 25,
     "fadeInDuration": 0
   },
   {
@@ -5310,13 +5310,13 @@
     "radius": 2000,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 25.0,
+    "duration": 3000,
+    "range": 25,
     "fadeInDuration": 0
   },
   {
@@ -5329,13 +5329,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -5348,13 +5348,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -5367,13 +5367,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -5386,13 +5386,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -5405,13 +5405,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -5424,13 +5424,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -5443,13 +5443,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -5462,13 +5462,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -5481,13 +5481,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -5500,13 +5500,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -5519,13 +5519,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -5538,13 +5538,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -5557,13 +5557,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -5576,13 +5576,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -5595,13 +5595,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -5614,13 +5614,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -5633,13 +5633,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -5652,13 +5652,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -5671,13 +5671,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -5690,13 +5690,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -5709,13 +5709,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -5728,13 +5728,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -5747,13 +5747,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -5766,13 +5766,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -5785,13 +5785,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -5804,13 +5804,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -5823,13 +5823,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -5842,13 +5842,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -5861,13 +5861,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -5880,13 +5880,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -5899,13 +5899,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -5918,13 +5918,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -5937,13 +5937,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -5956,13 +5956,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -5975,13 +5975,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -5994,13 +5994,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -6013,13 +6013,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -6032,13 +6032,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -6051,13 +6051,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -6070,13 +6070,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -6089,13 +6089,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -6108,13 +6108,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -6127,13 +6127,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -6146,13 +6146,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -6165,13 +6165,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -6184,13 +6184,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -6203,13 +6203,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -6222,13 +6222,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -6241,13 +6241,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -6260,13 +6260,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -6279,13 +6279,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -6298,13 +6298,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -6317,13 +6317,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -6336,13 +6336,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -6355,13 +6355,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -6374,13 +6374,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -6393,13 +6393,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -6412,13 +6412,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -6431,13 +6431,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -6450,13 +6450,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -6469,13 +6469,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -6488,13 +6488,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -6507,13 +6507,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -6526,13 +6526,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -6545,13 +6545,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -6564,13 +6564,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -6583,13 +6583,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -6602,13 +6602,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -6621,13 +6621,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -6640,13 +6640,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -6659,13 +6659,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -6678,13 +6678,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -6697,13 +6697,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -6716,13 +6716,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -6735,13 +6735,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -6754,13 +6754,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -6773,13 +6773,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -6792,13 +6792,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -6811,13 +6811,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -6830,13 +6830,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -6849,13 +6849,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -6868,13 +6868,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -6887,13 +6887,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -6906,13 +6906,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -6925,13 +6925,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -6944,13 +6944,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -6963,13 +6963,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -6982,13 +6982,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -7001,13 +7001,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -7020,13 +7020,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -7039,13 +7039,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -7058,13 +7058,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -7077,13 +7077,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -7096,13 +7096,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -7115,13 +7115,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -7134,13 +7134,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -7153,13 +7153,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -7172,13 +7172,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -7191,13 +7191,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -7210,13 +7210,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -7229,13 +7229,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -7248,13 +7248,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -7267,13 +7267,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -7286,13 +7286,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -7305,13 +7305,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -7324,13 +7324,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -7343,13 +7343,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -7362,13 +7362,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -7381,13 +7381,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -7400,13 +7400,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -7419,13 +7419,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -7438,13 +7438,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -7457,13 +7457,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -7476,13 +7476,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -7495,13 +7495,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -7514,13 +7514,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -7533,13 +7533,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -7552,13 +7552,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -7571,13 +7571,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -7590,13 +7590,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -7609,13 +7609,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -7628,13 +7628,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -7647,13 +7647,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -7666,13 +7666,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -7685,13 +7685,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -7704,13 +7704,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -7723,13 +7723,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -7742,13 +7742,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -7761,13 +7761,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -7780,13 +7780,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -7799,13 +7799,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -7818,13 +7818,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -7837,13 +7837,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -7856,13 +7856,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -7875,13 +7875,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -7894,13 +7894,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -7913,13 +7913,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -7932,13 +7932,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -7951,13 +7951,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -7970,13 +7970,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -7989,13 +7989,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -8008,13 +8008,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -8027,13 +8027,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -8046,13 +8046,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -8065,13 +8065,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -8084,13 +8084,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -8103,13 +8103,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -8122,13 +8122,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -8141,13 +8141,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -8160,13 +8160,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -8179,13 +8179,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -8198,13 +8198,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -8217,13 +8217,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -8236,13 +8236,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -8255,13 +8255,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -8274,13 +8274,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -8293,13 +8293,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -8312,13 +8312,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -8331,13 +8331,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -8350,13 +8350,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -8369,13 +8369,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -8388,13 +8388,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -8407,13 +8407,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -8426,13 +8426,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -8445,13 +8445,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -8464,13 +8464,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -8483,13 +8483,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -8502,13 +8502,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -8521,13 +8521,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -8540,13 +8540,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -8559,13 +8559,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -8578,13 +8578,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -8597,13 +8597,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -8616,13 +8616,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -8635,13 +8635,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -8654,13 +8654,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -8673,13 +8673,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -8692,13 +8692,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -8711,13 +8711,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -8730,13 +8730,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -8749,13 +8749,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -8768,13 +8768,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -8787,13 +8787,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -8806,13 +8806,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -8825,13 +8825,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -8844,13 +8844,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -8863,13 +8863,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -8882,13 +8882,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -8901,13 +8901,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -8920,13 +8920,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -8939,13 +8939,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -8958,13 +8958,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -8977,13 +8977,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -8996,13 +8996,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -9015,13 +9015,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -9034,13 +9034,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -9053,13 +9053,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -9072,13 +9072,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -9091,13 +9091,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -9110,13 +9110,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -9129,13 +9129,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -9148,13 +9148,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -9167,13 +9167,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -9186,13 +9186,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -9205,13 +9205,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -9224,13 +9224,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -9243,13 +9243,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -9262,13 +9262,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -9281,13 +9281,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -9300,13 +9300,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -9319,13 +9319,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -9338,13 +9338,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -9357,13 +9357,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -9376,13 +9376,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -9395,13 +9395,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -9414,13 +9414,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -9433,13 +9433,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -9452,13 +9452,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -9471,13 +9471,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -9490,13 +9490,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -9509,13 +9509,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -9528,13 +9528,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -9547,13 +9547,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -9566,13 +9566,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -9585,13 +9585,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -9604,13 +9604,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -9623,13 +9623,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -9642,13 +9642,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -9661,13 +9661,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -9680,13 +9680,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -9699,13 +9699,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -9718,13 +9718,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -9737,13 +9737,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -9756,13 +9756,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -9775,13 +9775,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -9794,13 +9794,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -9813,13 +9813,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -9832,13 +9832,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -9851,13 +9851,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -9870,13 +9870,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -9889,13 +9889,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -9908,13 +9908,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -9927,13 +9927,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -9946,13 +9946,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -9965,13 +9965,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -9984,13 +9984,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -10003,13 +10003,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -10022,13 +10022,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -10041,13 +10041,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -10060,13 +10060,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -10079,13 +10079,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -10098,13 +10098,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -10117,13 +10117,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -10136,13 +10136,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -10155,13 +10155,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -10174,13 +10174,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -10193,13 +10193,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -10212,13 +10212,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -10231,13 +10231,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -10250,13 +10250,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -10269,13 +10269,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -10288,13 +10288,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -10307,13 +10307,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -10326,13 +10326,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -10345,13 +10345,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -10364,13 +10364,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -10383,13 +10383,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -10402,13 +10402,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -10421,13 +10421,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -10440,13 +10440,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -10459,13 +10459,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -10478,13 +10478,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -10497,13 +10497,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -10516,13 +10516,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -10535,13 +10535,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -10554,13 +10554,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -10573,13 +10573,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -10592,13 +10592,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -10611,13 +10611,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -10630,13 +10630,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -10649,13 +10649,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -10668,13 +10668,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -10687,13 +10687,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -10706,13 +10706,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -10725,13 +10725,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -10744,13 +10744,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -10763,13 +10763,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -10782,13 +10782,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -10801,13 +10801,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -10820,13 +10820,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -10839,13 +10839,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -10858,13 +10858,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -10877,13 +10877,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -10896,13 +10896,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -10915,13 +10915,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -10934,13 +10934,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -10953,13 +10953,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -10972,13 +10972,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -10991,13 +10991,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -11010,13 +11010,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -11029,13 +11029,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -11048,13 +11048,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -11067,13 +11067,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -11086,13 +11086,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -11105,13 +11105,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -11124,13 +11124,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -11143,13 +11143,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -11162,13 +11162,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -11181,13 +11181,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -11200,13 +11200,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -11219,13 +11219,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -11238,13 +11238,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -11257,13 +11257,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -11276,13 +11276,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -11295,13 +11295,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -11314,13 +11314,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -11333,13 +11333,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -11352,13 +11352,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -11371,13 +11371,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -11390,13 +11390,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -11409,13 +11409,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -11428,13 +11428,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -11447,13 +11447,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -11466,13 +11466,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -11485,13 +11485,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -11504,13 +11504,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -11523,13 +11523,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -11542,13 +11542,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -11559,15 +11559,15 @@
     "height": 50,
     "alignment": "CENTER",
     "radius": 1500,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -11578,15 +11578,15 @@
     "height": 50,
     "alignment": "CENTER",
     "radius": 1500,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -11597,15 +11597,15 @@
     "height": 50,
     "alignment": "CENTER",
     "radius": 1500,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -11616,15 +11616,15 @@
     "height": 50,
     "alignment": "CENTER",
     "radius": 1500,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -11635,15 +11635,15 @@
     "height": 50,
     "alignment": "CENTER",
     "radius": 1500,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -11654,15 +11654,15 @@
     "height": 50,
     "alignment": "CENTER",
     "radius": 1500,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -11673,15 +11673,15 @@
     "height": 50,
     "alignment": "CENTER",
     "radius": 1500,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -11692,15 +11692,15 @@
     "height": 50,
     "alignment": "CENTER",
     "radius": 1500,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -11711,15 +11711,15 @@
     "height": 50,
     "alignment": "CENTER",
     "radius": 1500,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -11730,15 +11730,15 @@
     "height": 50,
     "alignment": "CENTER",
     "radius": 1500,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -11749,15 +11749,15 @@
     "height": 50,
     "alignment": "CENTER",
     "radius": 1500,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -11768,15 +11768,15 @@
     "height": 50,
     "alignment": "CENTER",
     "radius": 1500,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -11787,15 +11787,15 @@
     "height": 50,
     "alignment": "CENTER",
     "radius": 1500,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -11806,15 +11806,15 @@
     "height": 50,
     "alignment": "CENTER",
     "radius": 1500,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -11825,15 +11825,15 @@
     "height": 50,
     "alignment": "CENTER",
     "radius": 1500,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -11844,15 +11844,15 @@
     "height": 50,
     "alignment": "CENTER",
     "radius": 1500,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -11863,15 +11863,15 @@
     "height": 50,
     "alignment": "CENTER",
     "radius": 1500,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -11882,15 +11882,15 @@
     "height": 50,
     "alignment": "CENTER",
     "radius": 1500,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -11901,15 +11901,15 @@
     "height": 50,
     "alignment": "CENTER",
     "radius": 1500,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -11920,15 +11920,15 @@
     "height": 50,
     "alignment": "CENTER",
     "radius": 1500,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -11939,15 +11939,15 @@
     "height": 50,
     "alignment": "CENTER",
     "radius": 1500,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -11958,15 +11958,15 @@
     "height": 50,
     "alignment": "CENTER",
     "radius": 1500,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -11977,15 +11977,15 @@
     "height": 50,
     "alignment": "CENTER",
     "radius": 1500,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -11996,15 +11996,15 @@
     "height": 50,
     "alignment": "CENTER",
     "radius": 1500,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -12015,15 +12015,15 @@
     "height": 50,
     "alignment": "CENTER",
     "radius": 1500,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -12034,15 +12034,15 @@
     "height": 50,
     "alignment": "CENTER",
     "radius": 1500,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -12053,15 +12053,15 @@
     "height": 50,
     "alignment": "CENTER",
     "radius": 1500,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -12072,15 +12072,15 @@
     "height": 50,
     "alignment": "CENTER",
     "radius": 1500,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -12091,15 +12091,15 @@
     "height": 50,
     "alignment": "CENTER",
     "radius": 1500,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -12110,15 +12110,15 @@
     "height": 50,
     "alignment": "CENTER",
     "radius": 1500,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -12129,15 +12129,15 @@
     "height": 50,
     "alignment": "CENTER",
     "radius": 1500,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -12148,15 +12148,15 @@
     "height": 50,
     "alignment": "CENTER",
     "radius": 1500,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -12167,15 +12167,15 @@
     "height": 50,
     "alignment": "CENTER",
     "radius": 1500,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -12186,15 +12186,15 @@
     "height": 50,
     "alignment": "CENTER",
     "radius": 1500,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -12205,15 +12205,15 @@
     "height": 50,
     "alignment": "CENTER",
     "radius": 1500,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -12224,15 +12224,15 @@
     "height": 50,
     "alignment": "CENTER",
     "radius": 1500,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -12243,15 +12243,15 @@
     "height": 50,
     "alignment": "CENTER",
     "radius": 1500,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -12262,15 +12262,15 @@
     "height": 50,
     "alignment": "CENTER",
     "radius": 1500,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -12281,15 +12281,15 @@
     "height": 50,
     "alignment": "CENTER",
     "radius": 1500,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -12300,15 +12300,15 @@
     "height": 50,
     "alignment": "CENTER",
     "radius": 1500,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -12319,15 +12319,15 @@
     "height": 50,
     "alignment": "CENTER",
     "radius": 1500,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -12338,15 +12338,15 @@
     "height": 50,
     "alignment": "CENTER",
     "radius": 1500,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -12357,15 +12357,15 @@
     "height": 50,
     "alignment": "CENTER",
     "radius": 1500,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -12376,15 +12376,15 @@
     "height": 50,
     "alignment": "CENTER",
     "radius": 1500,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -12395,15 +12395,15 @@
     "height": 50,
     "alignment": "CENTER",
     "radius": 1500,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -12414,15 +12414,15 @@
     "height": 50,
     "alignment": "CENTER",
     "radius": 1500,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -12433,15 +12433,15 @@
     "height": 50,
     "alignment": "CENTER",
     "radius": 1500,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -12452,15 +12452,15 @@
     "height": 50,
     "alignment": "CENTER",
     "radius": 1500,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -12471,15 +12471,15 @@
     "height": 50,
     "alignment": "CENTER",
     "radius": 1500,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -12490,15 +12490,15 @@
     "height": 50,
     "alignment": "CENTER",
     "radius": 1500,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -12509,15 +12509,15 @@
     "height": 50,
     "alignment": "CENTER",
     "radius": 1500,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -12528,15 +12528,15 @@
     "height": 50,
     "alignment": "CENTER",
     "radius": 1500,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -12547,15 +12547,15 @@
     "height": 50,
     "alignment": "CENTER",
     "radius": 1500,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -12566,15 +12566,15 @@
     "height": 50,
     "alignment": "CENTER",
     "radius": 1500,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -12585,15 +12585,15 @@
     "height": 50,
     "alignment": "CENTER",
     "radius": 1500,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -12604,15 +12604,15 @@
     "height": 50,
     "alignment": "CENTER",
     "radius": 1500,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -12623,15 +12623,15 @@
     "height": 50,
     "alignment": "CENTER",
     "radius": 1500,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -12642,15 +12642,15 @@
     "height": 50,
     "alignment": "CENTER",
     "radius": 1500,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -12661,15 +12661,15 @@
     "height": 50,
     "alignment": "CENTER",
     "radius": 1500,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -12682,13 +12682,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -12701,13 +12701,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -12720,13 +12720,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -12739,13 +12739,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -12756,15 +12756,15 @@
     "height": 50,
     "alignment": "CENTER",
     "radius": 1500,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -12775,15 +12775,15 @@
     "height": 50,
     "alignment": "CENTER",
     "radius": 1500,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -12794,15 +12794,15 @@
     "height": 50,
     "alignment": "CENTER",
     "radius": 1500,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -12813,15 +12813,15 @@
     "height": 50,
     "alignment": "CENTER",
     "radius": 1500,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -12832,15 +12832,15 @@
     "height": 50,
     "alignment": "CENTER",
     "radius": 1500,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -12851,15 +12851,15 @@
     "height": 50,
     "alignment": "CENTER",
     "radius": 1500,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -12870,15 +12870,15 @@
     "height": 50,
     "alignment": "CENTER",
     "radius": 1500,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -12889,15 +12889,15 @@
     "height": 50,
     "alignment": "CENTER",
     "radius": 1500,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -12908,15 +12908,15 @@
     "height": 50,
     "alignment": "CENTER",
     "radius": 1500,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -12927,15 +12927,15 @@
     "height": 50,
     "alignment": "CENTER",
     "radius": 1500,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -12946,15 +12946,15 @@
     "height": 50,
     "alignment": "CENTER",
     "radius": 1500,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -12965,15 +12965,15 @@
     "height": 50,
     "alignment": "CENTER",
     "radius": 1500,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -12984,15 +12984,15 @@
     "height": 50,
     "alignment": "CENTER",
     "radius": 1500,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -13003,15 +13003,15 @@
     "height": 50,
     "alignment": "CENTER",
     "radius": 1500,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -13022,15 +13022,15 @@
     "height": 50,
     "alignment": "CENTER",
     "radius": 1500,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -13041,15 +13041,15 @@
     "height": 50,
     "alignment": "CENTER",
     "radius": 1500,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -13060,15 +13060,15 @@
     "height": 50,
     "alignment": "CENTER",
     "radius": 1500,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -13079,15 +13079,15 @@
     "height": 50,
     "alignment": "CENTER",
     "radius": 1500,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -13098,15 +13098,15 @@
     "height": 50,
     "alignment": "CENTER",
     "radius": 1500,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -13117,15 +13117,15 @@
     "height": 50,
     "alignment": "CENTER",
     "radius": 1500,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -13136,15 +13136,15 @@
     "height": 50,
     "alignment": "CENTER",
     "radius": 1500,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -13155,15 +13155,15 @@
     "height": 50,
     "alignment": "CENTER",
     "radius": 1500,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -13174,15 +13174,15 @@
     "height": 50,
     "alignment": "CENTER",
     "radius": 1500,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -13193,15 +13193,15 @@
     "height": 50,
     "alignment": "CENTER",
     "radius": 1500,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -13212,15 +13212,15 @@
     "height": 50,
     "alignment": "CENTER",
     "radius": 1500,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -13233,13 +13233,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -13252,13 +13252,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -13271,13 +13271,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -13290,13 +13290,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -13309,13 +13309,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -13328,13 +13328,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -13347,13 +13347,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -13366,13 +13366,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -13385,13 +13385,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -13404,13 +13404,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -13423,13 +13423,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -13442,13 +13442,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -13461,13 +13461,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -13480,13 +13480,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -13499,13 +13499,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -13518,13 +13518,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -13537,13 +13537,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -13556,13 +13556,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -13575,13 +13575,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -13594,13 +13594,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -13613,13 +13613,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -13632,13 +13632,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -13651,13 +13651,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -13670,13 +13670,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -13689,13 +13689,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -13708,13 +13708,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -13727,13 +13727,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -13746,13 +13746,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -13765,13 +13765,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -13784,13 +13784,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -13803,13 +13803,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -13822,13 +13822,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -13841,13 +13841,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -13860,13 +13860,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -13879,13 +13879,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -13898,13 +13898,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -13917,13 +13917,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -13936,13 +13936,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -13955,13 +13955,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -13974,13 +13974,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -13993,13 +13993,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -14012,13 +14012,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -14031,13 +14031,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -14050,13 +14050,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -14069,13 +14069,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -14088,13 +14088,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -14107,13 +14107,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -14126,13 +14126,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -14145,13 +14145,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -14164,13 +14164,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -14183,13 +14183,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -14202,13 +14202,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -14221,13 +14221,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -14240,13 +14240,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -14259,13 +14259,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -14278,13 +14278,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -14297,13 +14297,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -14316,13 +14316,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -14335,13 +14335,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -14354,13 +14354,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -14373,13 +14373,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -14392,13 +14392,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -14411,13 +14411,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -14430,13 +14430,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -14449,13 +14449,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -14468,13 +14468,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -14487,13 +14487,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -14506,13 +14506,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -14525,13 +14525,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -14544,13 +14544,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -14563,13 +14563,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -14582,13 +14582,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -14601,13 +14601,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -14620,13 +14620,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -14639,13 +14639,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -14658,13 +14658,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -14677,13 +14677,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -14696,13 +14696,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -14715,13 +14715,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -14734,13 +14734,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -14753,13 +14753,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -14772,13 +14772,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -14791,13 +14791,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -14810,13 +14810,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -14829,13 +14829,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -14848,13 +14848,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -14867,13 +14867,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -14886,13 +14886,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -14905,13 +14905,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -14924,13 +14924,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -14943,13 +14943,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -14962,17 +14962,17 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
-    "description": "Gu\u0027Tanoth",
+    "description": "Gu'Tanoth",
     "worldX": 2494,
     "worldY": 3019,
     "plane": 0,
@@ -14981,17 +14981,17 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
-    "description": "Gu\u0027Tanoth",
+    "description": "Gu'Tanoth",
     "worldX": 2496,
     "worldY": 3020,
     "plane": 0,
@@ -15000,17 +15000,17 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
-    "description": "Gu\u0027Tanoth",
+    "description": "Gu'Tanoth",
     "worldX": 2499,
     "worldY": 3021,
     "plane": 0,
@@ -15019,17 +15019,17 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
-    "description": "Gu\u0027Tanoth",
+    "description": "Gu'Tanoth",
     "worldX": 2503,
     "worldY": 3020,
     "plane": 0,
@@ -15038,17 +15038,17 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
-    "description": "Gu\u0027Tanoth",
+    "description": "Gu'Tanoth",
     "worldX": 2507,
     "worldY": 3018,
     "plane": 0,
@@ -15057,17 +15057,17 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
-    "description": "Gu\u0027Tanoth",
+    "description": "Gu'Tanoth",
     "worldX": 2508,
     "worldY": 2999,
     "plane": 0,
@@ -15076,17 +15076,17 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
-    "description": "Gu\u0027Tanoth",
+    "description": "Gu'Tanoth",
     "worldX": 2508,
     "worldY": 3028,
     "plane": 0,
@@ -15095,17 +15095,17 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
-    "description": "Gu\u0027Tanoth",
+    "description": "Gu'Tanoth",
     "worldX": 2509,
     "worldY": 3008,
     "plane": 0,
@@ -15114,17 +15114,17 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
-    "description": "Gu\u0027Tanoth",
+    "description": "Gu'Tanoth",
     "worldX": 2510,
     "worldY": 3001,
     "plane": 0,
@@ -15133,17 +15133,17 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
-    "description": "Gu\u0027Tanoth",
+    "description": "Gu'Tanoth",
     "worldX": 2510,
     "worldY": 3015,
     "plane": 0,
@@ -15152,17 +15152,17 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
-    "description": "Gu\u0027Tanoth",
+    "description": "Gu'Tanoth",
     "worldX": 2511,
     "worldY": 3005,
     "plane": 0,
@@ -15171,17 +15171,17 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
-    "description": "Gu\u0027Tanoth",
+    "description": "Gu'Tanoth",
     "worldX": 2511,
     "worldY": 3031,
     "plane": 0,
@@ -15190,17 +15190,17 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
-    "description": "Gu\u0027Tanoth",
+    "description": "Gu'Tanoth",
     "worldX": 2512,
     "worldY": 3009,
     "plane": 0,
@@ -15209,17 +15209,17 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
-    "description": "Gu\u0027Tanoth",
+    "description": "Gu'Tanoth",
     "worldX": 2514,
     "worldY": 3013,
     "plane": 0,
@@ -15228,17 +15228,17 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
-    "description": "Gu\u0027Tanoth",
+    "description": "Gu'Tanoth",
     "worldX": 2515,
     "worldY": 3032,
     "plane": 0,
@@ -15247,17 +15247,17 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
-    "description": "Gu\u0027Tanoth",
+    "description": "Gu'Tanoth",
     "worldX": 2519,
     "worldY": 3031,
     "plane": 0,
@@ -15266,17 +15266,17 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
-    "description": "Gu\u0027Tanoth",
+    "description": "Gu'Tanoth",
     "worldX": 2522,
     "worldY": 3029,
     "plane": 0,
@@ -15285,17 +15285,17 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
-    "description": "Gu\u0027Tanoth",
+    "description": "Gu'Tanoth",
     "worldX": 2525,
     "worldY": 3027,
     "plane": 0,
@@ -15304,17 +15304,17 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
-    "description": "Gu\u0027Tanoth",
+    "description": "Gu'Tanoth",
     "worldX": 2529,
     "worldY": 3025,
     "plane": 0,
@@ -15323,17 +15323,17 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
-    "description": "Gu\u0027Tanoth",
+    "description": "Gu'Tanoth",
     "worldX": 2530,
     "worldY": 3008,
     "plane": 0,
@@ -15342,17 +15342,17 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
-    "description": "Gu\u0027Tanoth",
+    "description": "Gu'Tanoth",
     "worldX": 2533,
     "worldY": 3005,
     "plane": 0,
@@ -15361,17 +15361,17 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
-    "description": "Gu\u0027Tanoth",
+    "description": "Gu'Tanoth",
     "worldX": 2533,
     "worldY": 3011,
     "plane": 0,
@@ -15380,17 +15380,17 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
-    "description": "Gu\u0027Tanoth",
+    "description": "Gu'Tanoth",
     "worldX": 2533,
     "worldY": 3026,
     "plane": 0,
@@ -15399,17 +15399,17 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
-    "description": "Gu\u0027Tanoth",
+    "description": "Gu'Tanoth",
     "worldX": 2534,
     "worldY": 3038,
     "plane": 0,
@@ -15418,17 +15418,17 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
-    "description": "Gu\u0027Tanoth",
+    "description": "Gu'Tanoth",
     "worldX": 2535,
     "worldY": 3017,
     "plane": 0,
@@ -15437,17 +15437,17 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
-    "description": "Gu\u0027Tanoth",
+    "description": "Gu'Tanoth",
     "worldX": 2535,
     "worldY": 3020,
     "plane": 0,
@@ -15456,17 +15456,17 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
-    "description": "Gu\u0027Tanoth",
+    "description": "Gu'Tanoth",
     "worldX": 2536,
     "worldY": 3008,
     "plane": 0,
@@ -15475,17 +15475,17 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
-    "description": "Gu\u0027Tanoth",
+    "description": "Gu'Tanoth",
     "worldX": 2536,
     "worldY": 3024,
     "plane": 0,
@@ -15494,17 +15494,17 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
-    "description": "Gu\u0027Tanoth",
+    "description": "Gu'Tanoth",
     "worldX": 2536,
     "worldY": 3027,
     "plane": 0,
@@ -15513,17 +15513,17 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
-    "description": "Gu\u0027Tanoth",
+    "description": "Gu'Tanoth",
     "worldX": 2536,
     "worldY": 3031,
     "plane": 0,
@@ -15532,17 +15532,17 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
-    "description": "Gu\u0027Tanoth",
+    "description": "Gu'Tanoth",
     "worldX": 2536,
     "worldY": 3035,
     "plane": 0,
@@ -15551,17 +15551,17 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
-    "description": "Gu\u0027Tanoth",
+    "description": "Gu'Tanoth",
     "worldX": 2536,
     "worldY": 3040,
     "plane": 0,
@@ -15570,17 +15570,17 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
-    "description": "Gu\u0027Tanoth",
+    "description": "Gu'Tanoth",
     "worldX": 2537,
     "worldY": 3004,
     "plane": 0,
@@ -15589,17 +15589,17 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
-    "description": "Gu\u0027Tanoth",
+    "description": "Gu'Tanoth",
     "worldX": 2538,
     "worldY": 3011,
     "plane": 0,
@@ -15608,17 +15608,17 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
-    "description": "Gu\u0027Tanoth",
+    "description": "Gu'Tanoth",
     "worldX": 2541,
     "worldY": 3006,
     "plane": 0,
@@ -15627,13 +15627,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -15646,13 +15646,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -15665,13 +15665,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -15684,13 +15684,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -15703,13 +15703,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -15722,13 +15722,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -15741,13 +15741,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -15760,13 +15760,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -15779,13 +15779,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -15798,13 +15798,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -15817,13 +15817,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -15836,13 +15836,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -15855,13 +15855,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -15874,13 +15874,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -15893,13 +15893,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -15912,13 +15912,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -15931,13 +15931,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -15950,13 +15950,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -15969,13 +15969,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -15988,13 +15988,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -16007,13 +16007,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -16026,13 +16026,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -16045,13 +16045,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -16064,13 +16064,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -16083,13 +16083,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -16102,13 +16102,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -16121,13 +16121,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -16140,13 +16140,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -16159,13 +16159,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -16178,13 +16178,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -16197,13 +16197,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -16216,13 +16216,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -16235,13 +16235,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -16254,13 +16254,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -16273,13 +16273,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -16292,13 +16292,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -16311,13 +16311,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -16330,13 +16330,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -16349,13 +16349,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -16368,13 +16368,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -16387,13 +16387,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -16406,13 +16406,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -16425,13 +16425,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -16444,13 +16444,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -16463,13 +16463,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -16482,13 +16482,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -16501,13 +16501,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -16520,13 +16520,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -16539,13 +16539,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -16558,13 +16558,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -16577,13 +16577,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -16596,13 +16596,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -16615,13 +16615,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -16634,13 +16634,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -16653,13 +16653,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -16672,13 +16672,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -16691,13 +16691,13 @@
     "radius": 1500,
     "strength": 7.5,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -16710,13 +16710,13 @@
     "radius": 1250,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -16729,13 +16729,13 @@
     "radius": 1250,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -16748,13 +16748,13 @@
     "radius": 1250,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -16767,13 +16767,13 @@
     "radius": 1250,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -16786,13 +16786,13 @@
     "radius": 1250,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -16805,13 +16805,13 @@
     "radius": 1250,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -16824,13 +16824,13 @@
     "radius": 1250,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -16843,13 +16843,13 @@
     "radius": 1250,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -16862,13 +16862,13 @@
     "radius": 1250,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -16881,13 +16881,13 @@
     "radius": 1250,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -16900,13 +16900,13 @@
     "radius": 1250,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -16919,13 +16919,13 @@
     "radius": 1250,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -16938,13 +16938,13 @@
     "radius": 1250,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -16957,13 +16957,13 @@
     "radius": 1250,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -16976,13 +16976,13 @@
     "radius": 1250,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -16995,13 +16995,13 @@
     "radius": 1250,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -17014,13 +17014,13 @@
     "radius": 1250,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -17033,13 +17033,13 @@
     "radius": 1250,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -17052,13 +17052,13 @@
     "radius": 1250,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -17071,13 +17071,13 @@
     "radius": 1250,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -17090,13 +17090,13 @@
     "radius": 1250,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -17109,13 +17109,13 @@
     "radius": 1250,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -17128,13 +17128,13 @@
     "radius": 1250,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -17147,13 +17147,13 @@
     "radius": 1250,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -17166,13 +17166,13 @@
     "radius": 1250,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -17185,13 +17185,13 @@
     "radius": 1250,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -17204,13 +17204,13 @@
     "radius": 1250,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -17223,13 +17223,13 @@
     "radius": 1250,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -17242,13 +17242,13 @@
     "radius": 1250,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -17261,13 +17261,13 @@
     "radius": 1250,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -17280,13 +17280,13 @@
     "radius": 1250,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -17299,13 +17299,13 @@
     "radius": 1250,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -17318,13 +17318,13 @@
     "radius": 1250,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -17337,13 +17337,13 @@
     "radius": 1250,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -17356,13 +17356,13 @@
     "radius": 1250,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -17375,13 +17375,13 @@
     "radius": 1250,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -17394,13 +17394,13 @@
     "radius": 1250,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -17413,13 +17413,13 @@
     "radius": 1250,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -17432,13 +17432,13 @@
     "radius": 1250,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -17451,13 +17451,13 @@
     "radius": 1250,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -17470,13 +17470,13 @@
     "radius": 1250,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -17489,13 +17489,13 @@
     "radius": 1250,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -17508,13 +17508,13 @@
     "radius": 1250,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -17527,13 +17527,13 @@
     "radius": 1250,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -17546,13 +17546,13 @@
     "radius": 1250,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -17565,13 +17565,13 @@
     "radius": 1250,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -17584,13 +17584,13 @@
     "radius": 1250,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -17603,13 +17603,13 @@
     "radius": 1250,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -17622,13 +17622,13 @@
     "radius": 1250,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -17641,13 +17641,13 @@
     "radius": 1250,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -17660,13 +17660,13 @@
     "radius": 1250,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -17679,13 +17679,13 @@
     "radius": 1250,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -17698,13 +17698,13 @@
     "radius": 1250,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -17717,13 +17717,13 @@
     "radius": 1250,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -17736,13 +17736,13 @@
     "radius": 1250,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -17755,13 +17755,13 @@
     "radius": 1250,
     "strength": 7.5,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 10.0,
+    "duration": 3000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -17774,13 +17774,13 @@
     "radius": 300,
     "strength": 7.5,
     "color": [
-      0.9019608,
-      0.47058824,
-      0.019607844
+      243.31615,
+      181.0259,
+      42.6945
     ],
     "type": "FLICKER",
-    "duration": 1000.0,
-    "range": 20.0,
+    "duration": 1000,
+    "range": 20,
     "fadeInDuration": 0
   },
   {
@@ -17793,13 +17793,13 @@
     "radius": 300,
     "strength": 7.5,
     "color": [
-      0.9019608,
-      0.47058824,
-      0.019607844
+      243.31615,
+      181.0259,
+      42.6945
     ],
     "type": "FLICKER",
-    "duration": 1000.0,
-    "range": 20.0,
+    "duration": 1000,
+    "range": 20,
     "fadeInDuration": 0
   },
   {
@@ -17812,13 +17812,13 @@
     "radius": 300,
     "strength": 7.5,
     "color": [
-      0.9019608,
-      0.47058824,
-      0.019607844
+      243.31615,
+      181.0259,
+      42.6945
     ],
     "type": "FLICKER",
-    "duration": 1000.0,
-    "range": 20.0,
+    "duration": 1000,
+    "range": 20,
     "fadeInDuration": 0
   },
   {
@@ -17831,13 +17831,13 @@
     "radius": 300,
     "strength": 7.5,
     "color": [
-      0.9019608,
-      0.47058824,
-      0.019607844
+      243.31615,
+      181.0259,
+      42.6945
     ],
     "type": "FLICKER",
-    "duration": 1000.0,
-    "range": 20.0,
+    "duration": 1000,
+    "range": 20,
     "fadeInDuration": 0
   },
   {
@@ -17850,13 +17850,13 @@
     "radius": 300,
     "strength": 7.5,
     "color": [
-      0.9019608,
-      0.47058824,
-      0.019607844
+      243.31615,
+      181.0259,
+      42.6945
     ],
     "type": "FLICKER",
-    "duration": 1000.0,
-    "range": 20.0,
+    "duration": 1000,
+    "range": 20,
     "fadeInDuration": 0
   },
   {
@@ -17869,13 +17869,13 @@
     "radius": 300,
     "strength": 7.5,
     "color": [
-      0.9019608,
-      0.47058824,
-      0.019607844
+      243.31615,
+      181.0259,
+      42.6945
     ],
     "type": "FLICKER",
-    "duration": 1000.0,
-    "range": 20.0,
+    "duration": 1000,
+    "range": 20,
     "fadeInDuration": 0
   },
   {
@@ -17888,13 +17888,13 @@
     "radius": 300,
     "strength": 7.5,
     "color": [
-      0.9019608,
-      0.47058824,
-      0.019607844
+      243.31615,
+      181.0259,
+      42.6945
     ],
     "type": "FLICKER",
-    "duration": 1000.0,
-    "range": 20.0,
+    "duration": 1000,
+    "range": 20,
     "fadeInDuration": 0
   },
   {
@@ -17905,14 +17905,14 @@
     "height": 200,
     "alignment": "NORTHWEST",
     "radius": 1000,
-    "strength": 20.0,
+    "strength": 20,
     "color": [
-      0.7058824,
-      0.078431375,
-      0.8627451
+      217.66177,
+      80.17438,
+      238.4492
     ],
     "type": "STATIC",
-    "duration": 1000.0,
+    "duration": 1000,
     "range": 0.2,
     "fadeInDuration": 0
   },
@@ -17924,15 +17924,15 @@
     "height": 150,
     "alignment": "CENTER",
     "radius": 700,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "FLICKER",
-    "duration": 1000.0,
-    "range": 20.0,
+    "duration": 1000,
+    "range": 20,
     "fadeInDuration": 0
   },
   {
@@ -17943,15 +17943,15 @@
     "height": 150,
     "alignment": "CENTER",
     "radius": 700,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "FLICKER",
-    "duration": 1000.0,
-    "range": 20.0,
+    "duration": 1000,
+    "range": 20,
     "fadeInDuration": 0
   },
   {
@@ -17962,14 +17962,14 @@
     "height": 300,
     "alignment": "SOUTH",
     "radius": 600,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      1.0,
-      1.0,
-      1.0
+      255,
+      255,
+      255
     ],
     "type": "STATIC",
-    "duration": 1000.0,
+    "duration": 1000,
     "range": 0.2,
     "fadeInDuration": 0
   },
@@ -17983,12 +17983,12 @@
     "radius": 2000,
     "strength": 7.5,
     "color": [
-      1.0,
-      1.0,
-      1.0
+      255,
+      255,
+      255
     ],
     "type": "STATIC",
-    "duration": 1000.0,
+    "duration": 1000,
     "range": 0.2,
     "fadeInDuration": 0
   },
@@ -18000,14 +18000,14 @@
     "height": 200,
     "alignment": "NORTHEAST",
     "radius": 300,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      0.9882353,
-      0.47843137,
-      0.011764706
+      253.63197,
+      182.39111,
+      33.847893
     ],
     "type": "STATIC",
-    "duration": 1000.0,
+    "duration": 1000,
     "range": 0.2,
     "fadeInDuration": 0
   },
@@ -18021,13 +18021,13 @@
     "radius": 300,
     "strength": 12.5,
     "color": [
-      0.8627451,
-      0.23529412,
-      0.0
+      238.4492,
+      132.10184,
+      0
     ],
     "type": "PULSE",
-    "duration": 3200.0,
-    "range": 5.0,
+    "duration": 3200,
+    "range": 5,
     "fadeInDuration": 0
   },
   {
@@ -18040,13 +18040,13 @@
     "radius": 300,
     "strength": 12.5,
     "color": [
-      0.8627451,
-      0.23529412,
-      0.0
+      238.4492,
+      132.10184,
+      0
     ],
     "type": "PULSE",
-    "duration": 3200.0,
-    "range": 5.0,
+    "duration": 3200,
+    "range": 5,
     "fadeInDuration": 0
   },
   {
@@ -18059,13 +18059,13 @@
     "radius": 300,
     "strength": 12.5,
     "color": [
-      0.8627451,
-      0.23529412,
-      0.0
+      238.4492,
+      132.10184,
+      0
     ],
     "type": "PULSE",
-    "duration": 3200.0,
-    "range": 5.0,
+    "duration": 3200,
+    "range": 5,
     "fadeInDuration": 0
   },
   {
@@ -18078,13 +18078,13 @@
     "radius": 300,
     "strength": 12.5,
     "color": [
-      0.8627451,
-      0.23529412,
-      0.0
+      238.4492,
+      132.10184,
+      0
     ],
     "type": "PULSE",
-    "duration": 3200.0,
-    "range": 5.0,
+    "duration": 3200,
+    "range": 5,
     "fadeInDuration": 0
   },
   {
@@ -18097,13 +18097,13 @@
     "radius": 300,
     "strength": 12.5,
     "color": [
-      0.8627451,
-      0.23529412,
-      0.0
+      238.4492,
+      132.10184,
+      0
     ],
     "type": "PULSE",
-    "duration": 3200.0,
-    "range": 5.0,
+    "duration": 3200,
+    "range": 5,
     "fadeInDuration": 0
   },
   {
@@ -18116,13 +18116,13 @@
     "radius": 300,
     "strength": 12.5,
     "color": [
-      0.8627451,
-      0.23529412,
-      0.0
+      238.4492,
+      132.10184,
+      0
     ],
     "type": "PULSE",
-    "duration": 3200.0,
-    "range": 5.0,
+    "duration": 3200,
+    "range": 5,
     "fadeInDuration": 0
   },
   {
@@ -18135,13 +18135,13 @@
     "radius": 300,
     "strength": 12.5,
     "color": [
-      0.8627451,
-      0.23529412,
-      0.0
+      238.4492,
+      132.10184,
+      0
     ],
     "type": "PULSE",
-    "duration": 3200.0,
-    "range": 5.0,
+    "duration": 3200,
+    "range": 5,
     "fadeInDuration": 0
   },
   {
@@ -18154,13 +18154,13 @@
     "radius": 300,
     "strength": 12.5,
     "color": [
-      0.8627451,
-      0.23529412,
-      0.0
+      238.4492,
+      132.10184,
+      0
     ],
     "type": "PULSE",
-    "duration": 3200.0,
-    "range": 5.0,
+    "duration": 3200,
+    "range": 5,
     "fadeInDuration": 0
   },
   {
@@ -18173,13 +18173,13 @@
     "radius": 300,
     "strength": 12.5,
     "color": [
-      0.8627451,
-      0.23529412,
-      0.0
+      238.4492,
+      132.10184,
+      0
     ],
     "type": "PULSE",
-    "duration": 3200.0,
-    "range": 5.0,
+    "duration": 3200,
+    "range": 5,
     "fadeInDuration": 0
   },
   {
@@ -18192,13 +18192,13 @@
     "radius": 300,
     "strength": 12.5,
     "color": [
-      0.8627451,
-      0.23529412,
-      0.0
+      238.4492,
+      132.10184,
+      0
     ],
     "type": "PULSE",
-    "duration": 3200.0,
-    "range": 5.0,
+    "duration": 3200,
+    "range": 5,
     "fadeInDuration": 0
   },
   {
@@ -18211,13 +18211,13 @@
     "radius": 300,
     "strength": 12.5,
     "color": [
-      0.8627451,
-      0.23529412,
-      0.0
+      238.4492,
+      132.10184,
+      0
     ],
     "type": "PULSE",
-    "duration": 3200.0,
-    "range": 5.0,
+    "duration": 3200,
+    "range": 5,
     "fadeInDuration": 0
   },
   {
@@ -18230,13 +18230,13 @@
     "radius": 300,
     "strength": 12.5,
     "color": [
-      0.8627451,
-      0.23529412,
-      0.0
+      238.4492,
+      132.10184,
+      0
     ],
     "type": "PULSE",
-    "duration": 3200.0,
-    "range": 5.0,
+    "duration": 3200,
+    "range": 5,
     "fadeInDuration": 0
   },
   {
@@ -18249,13 +18249,13 @@
     "radius": 300,
     "strength": 12.5,
     "color": [
-      0.8627451,
-      0.23529412,
-      0.0
+      238.4492,
+      132.10184,
+      0
     ],
     "type": "PULSE",
-    "duration": 3200.0,
-    "range": 5.0,
+    "duration": 3200,
+    "range": 5,
     "fadeInDuration": 0
   },
   {
@@ -18268,13 +18268,13 @@
     "radius": 300,
     "strength": 12.5,
     "color": [
-      0.8627451,
-      0.23529412,
-      0.0
+      238.4492,
+      132.10184,
+      0
     ],
     "type": "PULSE",
-    "duration": 3200.0,
-    "range": 5.0,
+    "duration": 3200,
+    "range": 5,
     "fadeInDuration": 0
   },
   {
@@ -18287,13 +18287,13 @@
     "radius": 300,
     "strength": 12.5,
     "color": [
-      0.8627451,
-      0.23529412,
-      0.0
+      238.4492,
+      132.10184,
+      0
     ],
     "type": "PULSE",
-    "duration": 3200.0,
-    "range": 5.0,
+    "duration": 3200,
+    "range": 5,
     "fadeInDuration": 0
   },
   {
@@ -18306,13 +18306,13 @@
     "radius": 300,
     "strength": 12.5,
     "color": [
-      0.8627451,
-      0.23529412,
-      0.0
+      238.4492,
+      132.10184,
+      0
     ],
     "type": "PULSE",
-    "duration": 3200.0,
-    "range": 5.0,
+    "duration": 3200,
+    "range": 5,
     "fadeInDuration": 0
   },
   {
@@ -18325,13 +18325,13 @@
     "radius": 300,
     "strength": 12.5,
     "color": [
-      0.8627451,
-      0.23529412,
-      0.0
+      238.4492,
+      132.10184,
+      0
     ],
     "type": "PULSE",
-    "duration": 3200.0,
-    "range": 5.0,
+    "duration": 3200,
+    "range": 5,
     "fadeInDuration": 0
   },
   {
@@ -18344,13 +18344,13 @@
     "radius": 300,
     "strength": 12.5,
     "color": [
-      0.8627451,
-      0.23529412,
-      0.0
+      238.4492,
+      132.10184,
+      0
     ],
     "type": "PULSE",
-    "duration": 3200.0,
-    "range": 5.0,
+    "duration": 3200,
+    "range": 5,
     "fadeInDuration": 0
   },
   {
@@ -18363,13 +18363,13 @@
     "radius": 300,
     "strength": 12.5,
     "color": [
-      0.8627451,
-      0.23529412,
-      0.0
+      238.4492,
+      132.10184,
+      0
     ],
     "type": "PULSE",
-    "duration": 3200.0,
-    "range": 5.0,
+    "duration": 3200,
+    "range": 5,
     "fadeInDuration": 0
   },
   {
@@ -18382,13 +18382,13 @@
     "radius": 500,
     "strength": 12.5,
     "color": [
-      0.8627451,
-      0.23529412,
-      0.0
+      238.4492,
+      132.10184,
+      0
     ],
     "type": "PULSE",
-    "duration": 3200.0,
-    "range": 5.0,
+    "duration": 3200,
+    "range": 5,
     "fadeInDuration": 0
   },
   {
@@ -18401,13 +18401,13 @@
     "radius": 300,
     "strength": 12.5,
     "color": [
-      0.8627451,
-      0.23529412,
-      0.0
+      238.4492,
+      132.10184,
+      0
     ],
     "type": "PULSE",
-    "duration": 3200.0,
-    "range": 5.0,
+    "duration": 3200,
+    "range": 5,
     "fadeInDuration": 0
   },
   {
@@ -18420,13 +18420,13 @@
     "radius": 300,
     "strength": 12.5,
     "color": [
-      0.8627451,
-      0.23529412,
-      0.0
+      238.4492,
+      132.10184,
+      0
     ],
     "type": "PULSE",
-    "duration": 3200.0,
-    "range": 5.0,
+    "duration": 3200,
+    "range": 5,
     "fadeInDuration": 0
   },
   {
@@ -18439,13 +18439,13 @@
     "radius": 300,
     "strength": 12.5,
     "color": [
-      0.8627451,
-      0.23529412,
-      0.0
+      238.4492,
+      132.10184,
+      0
     ],
     "type": "PULSE",
-    "duration": 3200.0,
-    "range": 5.0,
+    "duration": 3200,
+    "range": 5,
     "fadeInDuration": 0
   },
   {
@@ -18458,13 +18458,13 @@
     "radius": 300,
     "strength": 12.5,
     "color": [
-      0.8627451,
-      0.23529412,
-      0.0
+      238.4492,
+      132.10184,
+      0
     ],
     "type": "PULSE",
-    "duration": 3200.0,
-    "range": 5.0,
+    "duration": 3200,
+    "range": 5,
     "fadeInDuration": 0
   },
   {
@@ -18475,14 +18475,14 @@
     "height": 800,
     "alignment": "EAST",
     "radius": 1500,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      1.0,
-      0.9529412,
-      0.8
+      255,
+      249.4737,
+      230.40408
     ],
     "type": "STATIC",
-    "duration": 1000.0,
+    "duration": 1000,
     "range": 0.2,
     "fadeInDuration": 0
   },
@@ -18494,14 +18494,14 @@
     "height": 260,
     "alignment": "CENTER",
     "radius": 700,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      0.50980395,
-      0.7058824,
-      1.0
+      187.73344,
+      217.66177,
+      255
     ],
     "type": "STATIC",
-    "duration": 1000.0,
+    "duration": 1000,
     "range": 0.2,
     "fadeInDuration": 0
   },
@@ -18513,14 +18513,14 @@
     "height": 260,
     "alignment": "CENTER",
     "radius": 700,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      0.50980395,
-      0.7058824,
-      1.0
+      187.73344,
+      217.66177,
+      255
     ],
     "type": "STATIC",
-    "duration": 1000.0,
+    "duration": 1000,
     "range": 0.2,
     "fadeInDuration": 0
   },
@@ -18532,14 +18532,14 @@
     "height": 260,
     "alignment": "CENTER",
     "radius": 700,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      0.50980395,
-      0.7058824,
-      1.0
+      187.73344,
+      217.66177,
+      255
     ],
     "type": "STATIC",
-    "duration": 1000.0,
+    "duration": 1000,
     "range": 0.2,
     "fadeInDuration": 0
   },
@@ -18551,14 +18551,14 @@
     "height": 260,
     "alignment": "CENTER",
     "radius": 700,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      0.50980395,
-      0.7058824,
-      1.0
+      187.73344,
+      217.66177,
+      255
     ],
     "type": "STATIC",
-    "duration": 1000.0,
+    "duration": 1000,
     "range": 0.2,
     "fadeInDuration": 0
   },
@@ -18569,13 +18569,13 @@
     "radius": 220,
     "strength": 7.5,
     "color": [
-      1.0,
-      0.0,
-      0.0
+      255,
+      0,
+      0
     ],
     "type": "STATIC",
-    "duration": 0.0,
-    "range": 0.0,
+    "duration": 0,
+    "range": 0,
     "npcIds": [
       "LAZY_HELLCAT",
       "LAZY_HELLCAT_6689",
@@ -18595,13 +18595,13 @@
     "radius": 220,
     "strength": 7.5,
     "color": [
-      1.0,
-      0.0,
-      0.0
+      255,
+      0,
+      0
     ],
     "type": "STATIC",
-    "duration": 0.0,
-    "range": 0.0,
+    "duration": 0,
+    "range": 0,
     "npcIds": [
       "HELLRAT",
       "HELLRAT_BEHEMOTH"
@@ -18612,15 +18612,15 @@
     "height": 20,
     "alignment": "CENTER",
     "radius": 220,
-    "strength": 15.0,
+    "strength": 15,
     "color": [
-      1.0,
-      0.63877946,
-      0.032875914
+      255,
+      208,
+      54
     ],
     "type": "PULSE",
-    "duration": 5000.0,
-    "range": 20.0,
+    "duration": 5000,
+    "range": 20,
     "npcIds": [
       "HELLPUPPY",
       "HELLPUPPY_3099"
@@ -18633,13 +18633,13 @@
     "radius": 120,
     "strength": 7.5,
     "color": [
-      1.0,
-      0.0,
-      0.0
+      255,
+      0,
+      0
     ],
     "type": "STATIC",
-    "duration": 0.0,
-    "range": 0.0,
+    "duration": 0,
+    "range": 0,
     "npcIds": [
       "IKKLE_HYDRA_8519",
       "IKKLE_HYDRA_8494"
@@ -18652,13 +18652,13 @@
     "radius": 120,
     "strength": 7.5,
     "color": [
-      0.5542271,
-      1.0,
-      0.0
+      195,
+      255,
+      0
     ],
     "type": "STATIC",
-    "duration": 0.0,
-    "range": 0.0,
+    "duration": 0,
+    "range": 0,
     "npcIds": [
       "IKKLE_HYDRA_8517",
       "IKKLE_HYDRA"
@@ -18671,13 +18671,13 @@
     "radius": 120,
     "strength": 7.5,
     "color": [
-      0.0,
-      0.2673581,
-      1.0
+      0,
+      140,
+      255
     ],
     "type": "STATIC",
-    "duration": 0.0,
-    "range": 0.0,
+    "duration": 0,
+    "range": 0,
     "npcIds": [
       "IKKLE_HYDRA_8518",
       "IKKLE_HYDRA_8493"
@@ -18690,13 +18690,13 @@
     "radius": 120,
     "strength": 7.5,
     "color": [
-      0.03155139,
-      0.7372048,
-      0.69408053
+      53,
+      222,
+      216
     ],
     "type": "STATIC",
-    "duration": 0.0,
-    "range": 0.0,
+    "duration": 0,
+    "range": 0,
     "npcIds": [
       "IKKLE_HYDRA_8520",
       "IKKLE_HYDRA_8495"
@@ -18707,15 +18707,15 @@
     "height": 20,
     "alignment": "CENTER",
     "radius": 320,
-    "strength": 25.0,
+    "strength": 25,
     "color": [
-      1.0,
-      0.20471011,
-      0.0
+      255,
+      124,
+      0
     ],
     "type": "FLICKER",
-    "duration": 0.0,
-    "range": 40.0,
+    "duration": 0,
+    "range": 40,
     "npcIds": [
       "PHOENIX_7368",
       "PHOENIX_7370"
@@ -18726,15 +18726,15 @@
     "height": 20,
     "alignment": "CENTER",
     "radius": 320,
-    "strength": 15.0,
+    "strength": 15,
     "color": [
-      1.0,
-      1.0,
-      1.0
+      255,
+      255,
+      255
     ],
     "type": "FLICKER",
-    "duration": 0.0,
-    "range": 40.0,
+    "duration": 0,
+    "range": 40,
     "npcIds": [
       "PHOENIX_3079",
       "PHOENIX_3083"
@@ -18747,13 +18747,13 @@
     "radius": 320,
     "strength": 22.5,
     "color": [
-      0.0029323183,
-      0.07176145,
-      1.0
+      18,
+      77,
+      255
     ],
     "type": "FLICKER",
-    "duration": 0.0,
-    "range": 40.0,
+    "duration": 0,
+    "range": 40,
     "npcIds": [
       "PHOENIX_3078",
       "PHOENIX_3082"
@@ -18766,13 +18766,13 @@
     "radius": 320,
     "strength": 22.5,
     "color": [
-      0.36859095,
-      0.0,
-      1.0
+      162,
+      0,
+      255
     ],
     "type": "FLICKER",
-    "duration": 0.0,
-    "range": 40.0,
+    "duration": 0,
+    "range": 40,
     "npcIds": [
       "PHOENIX_3080",
       "PHOENIX_3084"
@@ -18783,15 +18783,15 @@
     "height": 20,
     "alignment": "CENTER",
     "radius": 320,
-    "strength": 20.0,
+    "strength": 20,
     "color": [
-      0.17677432,
-      0.91575015,
-      0.08021926
+      116,
+      245,
+      81
     ],
     "type": "FLICKER",
-    "duration": 0.0,
-    "range": 40.0,
+    "duration": 0,
+    "range": 40,
     "npcIds": [
       "PHOENIX",
       "PHOENIX_3081"
@@ -18804,13 +18804,13 @@
     "radius": 100,
     "strength": 12.5,
     "color": [
-      0.9743002,
-      0.21951973,
-      0.022012994
+      252,
+      128,
+      45
     ],
     "type": "STATIC",
-    "duration": 0.0,
-    "range": 0.0,
+    "duration": 0,
+    "range": 0,
     "npcIds": [
       "TZREKZUK",
       "TZREKZUK_8011"
@@ -18823,13 +18823,13 @@
     "radius": 100,
     "strength": 12.5,
     "color": [
-      0.9743002,
-      0.21951973,
-      0.022012994
+      252,
+      128,
+      45
     ],
     "type": "STATIC",
-    "duration": 0.0,
-    "range": 0.0,
+    "duration": 0,
+    "range": 0,
     "npcIds": [
       "MIDNIGHT",
       "MIDNIGHT_7893"
@@ -18842,13 +18842,13 @@
     "radius": 100,
     "strength": 17.5,
     "color": [
-      1.0,
-      0.0,
-      0.0
+      255,
+      0,
+      0
     ],
     "type": "PULSE",
-    "duration": 2100.0,
-    "range": 10.0,
+    "duration": 2100,
+    "range": 10,
     "npcIds": [
       "RIFT_GUARDIAN",
       "RIFT_GUARDIAN_7354"
@@ -18861,13 +18861,13 @@
     "radius": 100,
     "strength": 17.5,
     "color": [
-      1.0,
-      1.0,
-      1.0
+      255,
+      255,
+      255
     ],
     "type": "PULSE",
-    "duration": 2100.0,
-    "range": 10.0,
+    "duration": 2100,
+    "range": 10,
     "npcIds": [
       "RIFT_GUARDIAN_7338",
       "RIFT_GUARDIAN_7355"
@@ -18880,13 +18880,13 @@
     "radius": 100,
     "strength": 17.5,
     "color": [
-      1.0,
-      0.37361506,
-      0.039947167
+      255,
+      163,
+      59
     ],
     "type": "PULSE",
-    "duration": 2100.0,
-    "range": 10.0,
+    "duration": 2100,
+    "range": 10,
     "npcIds": [
       "RIFT_GUARDIAN_7339",
       "RIFT_GUARDIAN_7356"
@@ -18899,13 +18899,13 @@
     "radius": 100,
     "strength": 17.5,
     "color": [
-      0.0029323183,
-      0.42050794,
-      1.0
+      18,
+      172,
+      255
     ],
     "type": "PULSE",
-    "duration": 2100.0,
-    "range": 10.0,
+    "duration": 2100,
+    "range": 10,
     "npcIds": [
       "RIFT_GUARDIAN_7340",
       "RIFT_GUARDIAN_7357"
@@ -18918,13 +18918,13 @@
     "radius": 100,
     "strength": 17.5,
     "color": [
-      0.48776522,
-      0.20471011,
-      0.08021926
+      184,
+      124,
+      81
     ],
     "type": "PULSE",
-    "duration": 2100.0,
-    "range": 10.0,
+    "duration": 2100,
+    "range": 10,
     "npcIds": [
       "RIFT_GUARDIAN_7341",
       "RIFT_GUARDIAN_7358"
@@ -18937,13 +18937,13 @@
     "radius": 100,
     "strength": 17.5,
     "color": [
-      0.014310519,
-      0.06003161,
-      0.54799354
+      37,
+      71,
+      194
     ],
     "type": "PULSE",
-    "duration": 2100.0,
-    "range": 10.0,
+    "duration": 2100,
+    "range": 10,
     "npcIds": [
       "RIFT_GUARDIAN_7342",
       "RIFT_GUARDIAN_7359"
@@ -18956,13 +18956,13 @@
     "radius": 100,
     "strength": 17.5,
     "color": [
-      1.0,
-      1.0,
-      0.0
+      255,
+      255,
+      0
     ],
     "type": "PULSE",
-    "duration": 2100.0,
-    "range": 10.0,
+    "duration": 2100,
+    "range": 10,
     "npcIds": [
       "RIFT_GUARDIAN_7360",
       "RIFT_GUARDIAN_7343"
@@ -18975,13 +18975,13 @@
     "radius": 100,
     "strength": 17.5,
     "color": [
-      1.0,
-      0.5604992,
-      0.0
+      255,
+      196,
+      0
     ],
     "type": "PULSE",
-    "duration": 2100.0,
-    "range": 10.0,
+    "duration": 2100,
+    "range": 10,
     "npcIds": [
       "RIFT_GUARDIAN_7344",
       "RIFT_GUARDIAN_7361"
@@ -18994,13 +18994,13 @@
     "radius": 100,
     "strength": 17.5,
     "color": [
-      0.0,
-      1.0,
-      0.0
+      0,
+      255,
+      0
     ],
     "type": "PULSE",
-    "duration": 2100.0,
-    "range": 10.0,
+    "duration": 2100,
+    "range": 10,
     "npcIds": [
       "RIFT_GUARDIAN_7345",
       "RIFT_GUARDIAN_7362"
@@ -19013,13 +19013,13 @@
     "radius": 100,
     "strength": 17.5,
     "color": [
-      0.004116177,
-      0.04614884,
-      0.8122415
+      21,
+      63,
+      232
     ],
     "type": "PULSE",
-    "duration": 2100.0,
-    "range": 10.0,
+    "duration": 2100,
+    "range": 10,
     "npcIds": [
       "RIFT_GUARDIAN_7346",
       "RIFT_GUARDIAN_7363"
@@ -19032,13 +19032,13 @@
     "radius": 100,
     "strength": 17.5,
     "color": [
-      1.0,
-      0.8671355,
-      0.8355278
+      255,
+      239,
+      235
     ],
     "type": "PULSE",
-    "duration": 2100.0,
-    "range": 10.0,
+    "duration": 2100,
+    "range": 10,
     "npcIds": [
       "RIFT_GUARDIAN_7347",
       "RIFT_GUARDIAN_7364"
@@ -19051,13 +19051,13 @@
     "radius": 100,
     "strength": 17.5,
     "color": [
-      0.17343903,
-      0.07176145,
-      1.0
+      115,
+      77,
+      255
     ],
     "type": "PULSE",
-    "duration": 2100.0,
-    "range": 10.0,
+    "duration": 2100,
+    "range": 10,
     "npcIds": [
       "RIFT_GUARDIAN_7348",
       "RIFT_GUARDIAN_7365"
@@ -19070,13 +19070,13 @@
     "radius": 100,
     "strength": 17.5,
     "color": [
-      0.91575015,
-      0.32503697,
-      1.0
+      245,
+      153,
+      255
     ],
     "type": "PULSE",
-    "duration": 2100.0,
-    "range": 10.0,
+    "duration": 2100,
+    "range": 10,
     "npcIds": [
       "RIFT_GUARDIAN_7349",
       "RIFT_GUARDIAN_7366"
@@ -19089,13 +19089,13 @@
     "radius": 100,
     "strength": 17.5,
     "color": [
-      1.0,
-      0.0,
-      0.0
+      255,
+      0,
+      0
     ],
     "type": "PULSE",
-    "duration": 2100.0,
-    "range": 10.0,
+    "duration": 2100,
+    "range": 10,
     "npcIds": [
       "RIFT_GUARDIAN_7350",
       "RIFT_GUARDIAN_7367"
@@ -19108,13 +19108,13 @@
     "radius": 100,
     "strength": 17.5,
     "color": [
-      0.66611695,
-      0.038472746,
-      0.024222942
+      212,
+      58,
+      47
     ],
     "type": "PULSE",
-    "duration": 2100.0,
-    "range": 10.0,
+    "duration": 2100,
+    "range": 10,
     "npcIds": [
       "RIFT_GUARDIAN_8024",
       "RIFT_GUARDIAN_8028"
@@ -19125,15 +19125,15 @@
     "height": 250,
     "alignment": "CENTER",
     "radius": 150,
-    "strength": 20.0,
+    "strength": 20,
     "color": [
-      1.0,
-      1.0,
-      1.0
+      255,
+      255,
+      255
     ],
     "type": "FLICKER",
-    "duration": 0.0,
-    "range": 80.0,
+    "duration": 0,
+    "range": 80,
     "npcIds": [
       "CHAOS_ELEMENTAL_JR_5907",
       "CHAOS_ELEMENTAL_JR"
@@ -19146,13 +19146,13 @@
     "radius": 150,
     "strength": 17.5,
     "color": [
-      0.34402567,
-      0.0,
-      1.0
+      157,
+      0,
+      255
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 20.0,
+    "duration": 3000,
+    "range": 20,
     "npcIds": [
       "SKOTOS_7671",
       "SKOTOS"
@@ -19165,13 +19165,13 @@
     "radius": 100,
     "strength": 17.5,
     "color": [
-      1.0,
-      0.32503697,
-      0.0
+      255,
+      153,
+      0
     ],
     "type": "PULSE",
-    "duration": 2100.0,
-    "range": 10.0,
+    "duration": 2100,
+    "range": 10,
     "npcIds": [
       "VANGUARD_8198",
       "VANGUARD_8203"
@@ -19182,15 +19182,15 @@
     "height": 100,
     "alignment": "CENTER",
     "radius": 150,
-    "strength": 20.0,
+    "strength": 20,
     "color": [
-      0.069727086,
-      0.0,
-      1.0
+      76,
+      0,
+      255
     ],
     "type": "PULSE",
-    "duration": 2400.0,
-    "range": 30.0,
+    "duration": 2400,
+    "range": 30,
     "npcIds": [
       "VASA_MINIRIO",
       "VASA_MINIRIO_8204"
@@ -19201,15 +19201,15 @@
     "height": 10,
     "alignment": "CENTER",
     "radius": 100,
-    "strength": 20.0,
+    "strength": 20,
     "color": [
-      1.0,
-      0.36859095,
-      0.017936433
+      255,
+      162,
+      41
     ],
     "type": "STATIC",
-    "duration": 2400.0,
-    "range": 0.0,
+    "duration": 2400,
+    "range": 0,
     "npcIds": [
       "TEKTINY",
       "TEKTINY_8202"
@@ -19220,15 +19220,15 @@
     "height": 10,
     "alignment": "CENTER",
     "radius": 100,
-    "strength": 20.0,
+    "strength": 20,
     "color": [
-      1.0,
-      0.113920934,
-      0.017936433
+      255,
+      95,
+      41
     ],
     "type": "STATIC",
-    "duration": 2400.0,
-    "range": 0.0,
+    "duration": 2400,
+    "range": 0,
     "npcIds": [
       "ENRAGED_TEKTINY",
       "ENRAGED_TEKTINY_9513"
@@ -19241,13 +19241,13 @@
     "radius": 100,
     "strength": 17.5,
     "color": [
-      1.0,
-      0.89126205,
-      0.0
+      255,
+      242,
+      0
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 15.0,
+    "duration": 3000,
+    "range": 15,
     "npcIds": [
       "SMOKE_DEVIL_6639",
       "SMOKE_DEVIL_6655"
@@ -19260,13 +19260,13 @@
     "radius": 100,
     "strength": 17.5,
     "color": [
-      0.0,
-      1.0,
-      1.0
+      0,
+      255,
+      255
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 15.0,
+    "duration": 3000,
+    "range": 15,
     "npcIds": [
       "YOUNGLLEF_8737",
       "YOUNGLLEF"
@@ -19279,13 +19279,13 @@
     "radius": 100,
     "strength": 17.5,
     "color": [
-      1.0,
-      0.0,
-      0.0
+      255,
+      0,
+      0
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 15.0,
+    "duration": 3000,
+    "range": 15,
     "npcIds": [
       "CORRUPTED_YOUNGLLEF_8738",
       "CORRUPTED_YOUNGLLEF"
@@ -19296,15 +19296,15 @@
     "height": 30,
     "alignment": "CENTER",
     "radius": 200,
-    "strength": 15.0,
+    "strength": 15,
     "color": [
-      0.0,
-      1.0,
-      1.0
+      0,
+      255,
+      255
     ],
     "type": "PULSE",
-    "duration": 3200.0,
-    "range": 20.0,
+    "duration": 3200,
+    "range": 20,
     "npcIds": [
       "TINY_TEMPOR",
       "TINY_TEMPOR_10637"
@@ -19317,13 +19317,13 @@
     "radius": 280,
     "strength": 7.5,
     "color": [
-      0.9743002,
-      0.19751643,
-      5.6921755E-5
+      252,
+      122,
+      3
     ],
     "type": "FLICKER",
-    "duration": 0.0,
-    "range": 20.0,
+    "duration": 0,
+    "range": 20,
     "npcIds": [
       "PYREFIEND",
       "PYREFIEND_434",
@@ -19339,13 +19339,13 @@
     "radius": 200,
     "strength": 7.5,
     "color": [
-      0.585973,
-      0.585973,
-      1.0
+      200,
+      200,
+      255
     ],
     "type": "FLICKER",
-    "duration": 1.0,
-    "range": 10.0,
+    "duration": 1,
+    "range": 10,
     "npcIds": [
       "GHOST_3975",
       "GHOST_3976",
@@ -19405,15 +19405,15 @@
     "height": 80,
     "alignment": "CENTER",
     "radius": 200,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      0.12752977,
-      0.46474114,
-      0.87513757
+      100,
+      180,
+      240
     ],
     "type": "FLICKER",
-    "duration": 1.0,
-    "range": 10.0,
+    "duration": 1,
+    "range": 10,
     "npcIds": [
       "FORGOTTEN_SOUL_10544",
       "FORGOTTEN_SOUL_10545",
@@ -19433,13 +19433,13 @@
     "radius": 300,
     "strength": 12.5,
     "color": [
-      0.12752977,
-      1.0,
-      0.12752977
+      100,
+      255,
+      100
     ],
     "type": "FLICKER",
-    "duration": 0.0,
-    "range": 10.0,
+    "duration": 0,
+    "range": 10,
     "npcIds": [
       "DROALAK",
       "DROALAK_3494",
@@ -19466,15 +19466,15 @@
     "height": 110,
     "alignment": "CENTER",
     "radius": 600,
-    "strength": 15.0,
+    "strength": 15,
     "color": [
-      0.59,
-      1.0,
-      0.2
+      200.6236,
+      255,
+      122.694916
     ],
     "type": "FLICKER",
-    "duration": 0.0,
-    "range": 10.0,
+    "duration": 0,
+    "range": 10,
     "npcIds": [
       "ABERRANT_SPECTRE",
       "ABERRANT_SPECTRE_3",
@@ -19489,15 +19489,15 @@
     "height": 110,
     "alignment": "CENTER",
     "radius": 600,
-    "strength": 15.0,
+    "strength": 15,
     "color": [
-      1.0,
-      0.62,
-      0.42
+      255,
+      205.19783,
+      171.90553
     ],
     "type": "FLICKER",
-    "duration": 0.0,
-    "range": 10.0,
+    "duration": 0,
+    "range": 10,
     "npcIds": [
       "DEVIANT_SPECTRE"
     ]
@@ -19507,15 +19507,15 @@
     "height": 200,
     "alignment": "CENTER",
     "radius": 1000,
-    "strength": 25.0,
+    "strength": 25,
     "color": [
-      0.59,
-      1.0,
-      0.2
+      200.6236,
+      255,
+      122.694916
     ],
     "type": "FLICKER",
-    "duration": 0.0,
-    "range": 10.0,
+    "duration": 0,
+    "range": 10,
     "npcIds": [
       "ABHORRENT_SPECTRE"
     ]
@@ -19525,15 +19525,15 @@
     "height": 200,
     "alignment": "CENTER",
     "radius": 1000,
-    "strength": 25.0,
+    "strength": 25,
     "color": [
-      1.0,
-      0.09,
-      1.0
+      255,
+      85.348495,
+      255
     ],
     "type": "FLICKER",
-    "duration": 0.0,
-    "range": 10.0,
+    "duration": 0,
+    "range": 10,
     "npcIds": [
       "REPUGNANT_SPECTRE"
     ]
@@ -19545,12 +19545,12 @@
     "radius": 220,
     "strength": 12.5,
     "color": [
-      1.0,
-      0.31118053,
-      0.12752977
+      255,
+      150,
+      100
     ],
     "type": "PULSE",
-    "duration": 1.0,
+    "duration": 1,
     "range": 0.7,
     "npcIds": [
       "AHRIM_THE_BLIGHTED",
@@ -19568,13 +19568,13 @@
     "radius": 500,
     "strength": 12.5,
     "color": [
-      0.0,
-      0.585973,
-      0.7592996
+      0,
+      200,
+      225
     ],
     "type": "PULSE",
-    "duration": 3200.0,
-    "range": 10.0,
+    "duration": 3200,
+    "range": 10,
     "npcIds": [
       "MEMORY_OF_SEREN_8784",
       "SEREN",
@@ -19595,13 +19595,13 @@
     "radius": 500,
     "strength": 17.5,
     "color": [
-      0.5054325,
-      0.32503697,
-      1.0
+      187,
+      153,
+      255
     ],
     "type": "PULSE",
-    "duration": 3200.0,
-    "range": 10.0,
+    "duration": 3200,
+    "range": 10,
     "npcIds": [
       "FRAGMENT_OF_SEREN",
       "FRAGMENT_OF_SEREN_8919",
@@ -19615,13 +19615,13 @@
     "radius": 800,
     "strength": 12.5,
     "color": [
-      0.0,
-      1.0,
-      1.0
+      0,
+      255,
+      255
     ],
     "type": "STATIC",
-    "duration": 0.0,
-    "range": 0.0,
+    "duration": 0,
+    "range": 0,
     "npcIds": [
       "CRYSTALLINE_HUNLLEF_9024",
       "CRYSTALLINE_HUNLLEF",
@@ -19636,13 +19636,13 @@
     "radius": 400,
     "strength": 12.5,
     "color": [
-      0.0,
-      1.0,
-      1.0
+      0,
+      255,
+      255
     ],
     "type": "STATIC",
-    "duration": 0.0,
-    "range": 0.0,
+    "duration": 0,
+    "range": 0,
     "npcIds": [
       "CRYSTALLINE_BAT"
     ]
@@ -19654,13 +19654,13 @@
     "radius": 400,
     "strength": 12.5,
     "color": [
-      0.0,
-      1.0,
-      1.0
+      0,
+      255,
+      255
     ],
     "type": "STATIC",
-    "duration": 0.0,
-    "range": 0.0,
+    "duration": 0,
+    "range": 0,
     "npcIds": [
       "CRYSTALLINE_RAT"
     ]
@@ -19672,13 +19672,13 @@
     "radius": 300,
     "strength": 12.5,
     "color": [
-      0.0,
-      1.0,
-      1.0
+      0,
+      255,
+      255
     ],
     "type": "STATIC",
-    "duration": 0.0,
-    "range": 0.0,
+    "duration": 0,
+    "range": 0,
     "npcIds": [
       "CRYSTALLINE_SPIDER"
     ]
@@ -19690,13 +19690,13 @@
     "radius": 600,
     "strength": 12.5,
     "color": [
-      0.0,
-      1.0,
-      1.0
+      0,
+      255,
+      255
     ],
     "type": "STATIC",
-    "duration": 0.0,
-    "range": 0.0,
+    "duration": 0,
+    "range": 0,
     "npcIds": [
       "CRYSTALLINE_DRAGON"
     ]
@@ -19708,13 +19708,13 @@
     "radius": 500,
     "strength": 12.5,
     "color": [
-      0.0,
-      1.0,
-      1.0
+      0,
+      255,
+      255
     ],
     "type": "STATIC",
-    "duration": 0.0,
-    "range": 0.0,
+    "duration": 0,
+    "range": 0,
     "npcIds": [
       "CRYSTALLINE_BEAR"
     ]
@@ -19726,13 +19726,13 @@
     "radius": 600,
     "strength": 12.5,
     "color": [
-      0.0,
-      1.0,
-      1.0
+      0,
+      255,
+      255
     ],
     "type": "STATIC",
-    "duration": 0.0,
-    "range": 0.0,
+    "duration": 0,
+    "range": 0,
     "npcIds": [
       "CRYSTALLINE_DARK_BEAST"
     ]
@@ -19744,13 +19744,13 @@
     "radius": 400,
     "strength": 12.5,
     "color": [
-      0.0,
-      1.0,
-      1.0
+      0,
+      255,
+      255
     ],
     "type": "STATIC",
-    "duration": 0.0,
-    "range": 0.0,
+    "duration": 0,
+    "range": 0,
     "npcIds": [
       "CRYSTALLINE_SCORPION"
     ]
@@ -19762,13 +19762,13 @@
     "radius": 500,
     "strength": 12.5,
     "color": [
-      0.0,
-      1.0,
-      1.0
+      0,
+      255,
+      255
     ],
     "type": "STATIC",
-    "duration": 0.0,
-    "range": 0.0,
+    "duration": 0,
+    "range": 0,
     "npcIds": [
       "CRYSTALLINE_UNICORN"
     ]
@@ -19780,13 +19780,13 @@
     "radius": 500,
     "strength": 12.5,
     "color": [
-      0.0,
-      1.0,
-      1.0
+      0,
+      255,
+      255
     ],
     "type": "STATIC",
-    "duration": 0.0,
-    "range": 0.0,
+    "duration": 0,
+    "range": 0,
     "npcIds": [
       "CRYSTALLINE_WOLF"
     ]
@@ -19798,13 +19798,13 @@
     "radius": 800,
     "strength": 12.5,
     "color": [
-      1.0,
-      0.0,
-      0.0
+      255,
+      0,
+      0
     ],
     "type": "STATIC",
-    "duration": 0.0,
-    "range": 0.0,
+    "duration": 0,
+    "range": 0,
     "npcIds": [
       "CORRUPTED_HUNLLEF",
       "CORRUPTED_HUNLLEF_9036",
@@ -19819,13 +19819,13 @@
     "radius": 400,
     "strength": 12.5,
     "color": [
-      1.0,
-      0.0,
-      0.0
+      255,
+      0,
+      0
     ],
     "type": "STATIC",
-    "duration": 0.0,
-    "range": 0.0,
+    "duration": 0,
+    "range": 0,
     "npcIds": [
       "CORRUPTED_BAT"
     ]
@@ -19837,13 +19837,13 @@
     "radius": 400,
     "strength": 12.5,
     "color": [
-      1.0,
-      0.0,
-      0.0
+      255,
+      0,
+      0
     ],
     "type": "STATIC",
-    "duration": 0.0,
-    "range": 0.0,
+    "duration": 0,
+    "range": 0,
     "npcIds": [
       "CORRUPTED_RAT"
     ]
@@ -19855,13 +19855,13 @@
     "radius": 300,
     "strength": 12.5,
     "color": [
-      1.0,
-      0.0,
-      0.0
+      255,
+      0,
+      0
     ],
     "type": "STATIC",
-    "duration": 0.0,
-    "range": 0.0,
+    "duration": 0,
+    "range": 0,
     "npcIds": [
       "CORRUPTED_SPIDER"
     ]
@@ -19873,13 +19873,13 @@
     "radius": 600,
     "strength": 12.5,
     "color": [
-      1.0,
-      0.0,
-      0.0
+      255,
+      0,
+      0
     ],
     "type": "STATIC",
-    "duration": 0.0,
-    "range": 0.0,
+    "duration": 0,
+    "range": 0,
     "npcIds": [
       "CORRUPTED_DRAGON"
     ]
@@ -19891,13 +19891,13 @@
     "radius": 500,
     "strength": 12.5,
     "color": [
-      1.0,
-      0.0,
-      0.0
+      255,
+      0,
+      0
     ],
     "type": "STATIC",
-    "duration": 0.0,
-    "range": 0.0,
+    "duration": 0,
+    "range": 0,
     "npcIds": [
       "CORRUPTED_BEAR"
     ]
@@ -19909,13 +19909,13 @@
     "radius": 600,
     "strength": 12.5,
     "color": [
-      1.0,
-      0.0,
-      0.0
+      255,
+      0,
+      0
     ],
     "type": "STATIC",
-    "duration": 0.0,
-    "range": 0.0,
+    "duration": 0,
+    "range": 0,
     "npcIds": [
       "CORRUPTED_DARK_BEAST"
     ]
@@ -19927,13 +19927,13 @@
     "radius": 400,
     "strength": 12.5,
     "color": [
-      1.0,
-      0.0,
-      0.0
+      255,
+      0,
+      0
     ],
     "type": "STATIC",
-    "duration": 0.0,
-    "range": 0.0,
+    "duration": 0,
+    "range": 0,
     "npcIds": [
       "CORRUPTED_SCORPION"
     ]
@@ -19945,13 +19945,13 @@
     "radius": 500,
     "strength": 12.5,
     "color": [
-      1.0,
-      0.0,
-      0.0
+      255,
+      0,
+      0
     ],
     "type": "STATIC",
-    "duration": 0.0,
-    "range": 0.0,
+    "duration": 0,
+    "range": 0,
     "npcIds": [
       "CORRUPTED_UNICORN"
     ]
@@ -19963,13 +19963,13 @@
     "radius": 500,
     "strength": 12.5,
     "color": [
-      1.0,
-      0.0,
-      0.0
+      255,
+      0,
+      0
     ],
     "type": "STATIC",
-    "duration": 0.0,
-    "range": 0.0,
+    "duration": 0,
+    "range": 0,
     "npcIds": [
       "CORRUPTED_WOLF"
     ]
@@ -19979,15 +19979,15 @@
     "height": 100,
     "alignment": "CENTER",
     "radius": 800,
-    "strength": 30.0,
+    "strength": 30,
     "color": [
-      1.0,
-      0.63877946,
-      0.032875914
+      255,
+      208,
+      54
     ],
     "type": "PULSE",
-    "duration": 5000.0,
-    "range": 20.0,
+    "duration": 5000,
+    "range": 20,
     "npcIds": [
       "CERBERUS",
       "CERBERUS_5863",
@@ -20001,13 +20001,13 @@
     "radius": 800,
     "strength": 17.5,
     "color": [
-      0.0,
-      1.0,
-      1.0
+      0,
+      255,
+      255
     ],
     "type": "PULSE",
-    "duration": 3200.0,
-    "range": 20.0,
+    "duration": 3200,
+    "range": 20,
     "npcIds": [
       "TEMPOROSS"
     ]
@@ -20019,13 +20019,13 @@
     "radius": 500,
     "strength": 17.5,
     "color": [
-      0.0,
-      1.0,
-      1.0
+      0,
+      255,
+      255
     ],
     "type": "PULSE",
-    "duration": 3200.0,
-    "range": 20.0,
+    "duration": 3200,
+    "range": 20,
     "npcIds": [
       10573,
       "TEMPOROSS_10574"
@@ -20038,13 +20038,13 @@
     "radius": 500,
     "strength": 17.5,
     "color": [
-      0.0,
-      1.0,
-      1.0
+      0,
+      255,
+      255
     ],
     "type": "PULSE",
-    "duration": 3200.0,
-    "range": 20.0,
+    "duration": 3200,
+    "range": 20,
     "npcIds": [
       "SPIRIT_POOL"
     ]
@@ -20054,15 +20054,15 @@
     "height": 220,
     "alignment": "CENTER",
     "radius": 400,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      0.0,
-      0.52344316,
-      0.9743002
+      0,
+      190,
+      252
     ],
     "type": "STATIC",
-    "duration": 0.0,
-    "range": 0.0,
+    "duration": 0,
+    "range": 0,
     "npcIds": [
       9672
     ]
@@ -20072,15 +20072,15 @@
     "height": 220,
     "alignment": "CENTER",
     "radius": 400,
-    "strength": 4.0,
+    "strength": 4,
     "color": [
-      0.22713655,
-      0.75189507,
-      1.0
+      130,
+      224,
+      255
     ],
     "type": "STATIC",
-    "duration": 0.0,
-    "range": 0.0,
+    "duration": 0,
+    "range": 0,
     "npcIds": [
       9673
     ]
@@ -20090,15 +20090,15 @@
     "height": 220,
     "alignment": "CENTER",
     "radius": 400,
-    "strength": 4.0,
+    "strength": 4,
     "color": [
-      0.9743002,
-      0.68002033,
-      0.0
+      252,
+      214,
+      0
     ],
     "type": "STATIC",
-    "duration": 0.0,
-    "range": 0.0,
+    "duration": 0,
+    "range": 0,
     "npcIds": [
       9674
     ]
@@ -20108,15 +20108,15 @@
     "height": 5,
     "alignment": "CENTER",
     "radius": 300,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      0.0,
-      0.585973,
-      1.0
+      0,
+      200,
+      255
     ],
     "type": "FLICKER",
-    "duration": 0.0,
-    "range": 40.0,
+    "duration": 0,
+    "range": 40,
     "npcIds": [
       "NYLOCAS_HAGIOS"
     ]
@@ -20126,15 +20126,15 @@
     "height": 30,
     "alignment": "CENTER",
     "radius": 500,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      0.0,
-      0.585973,
-      1.0
+      0,
+      200,
+      255
     ],
     "type": "FLICKER",
-    "duration": 0.0,
-    "range": 40.0,
+    "duration": 0,
+    "range": 40,
     "npcIds": [
       "NYLOCAS_HAGIOS_8347",
       "NYLOCAS_HAGIOS_8383"
@@ -20147,13 +20147,13 @@
     "radius": 1000,
     "strength": 12.5,
     "color": [
-      0.0,
-      0.585973,
-      1.0
+      0,
+      200,
+      255
     ],
     "type": "FLICKER",
-    "duration": 0.0,
-    "range": 40.0,
+    "duration": 0,
+    "range": 40,
     "npcIds": [
       "NYLOCAS_VASILIAS_8356"
     ]
@@ -20163,15 +20163,15 @@
     "height": 200,
     "alignment": "CENTER",
     "radius": 200,
-    "strength": 15.0,
+    "strength": 15,
     "color": [
-      1.0,
-      1.0,
-      1.0
+      255,
+      255,
+      255
     ],
     "type": "PULSE",
-    "duration": 4500.0,
-    "range": 10.0,
+    "duration": 4500,
+    "range": 10,
     "npcIds": [
       "FAIRY_CHEF",
       "FAIRY_3204",
@@ -20204,15 +20204,15 @@
     "height": 80,
     "alignment": "CENTER",
     "radius": 400,
-    "strength": 15.0,
+    "strength": 15,
     "color": [
-      0.0,
-      0.12752977,
-      1.0
+      0,
+      100,
+      255
     ],
     "type": "FLICKER",
-    "duration": 0.0,
-    "range": 10.0,
+    "duration": 0,
+    "range": 10,
     "npcIds": [
       "GREATER_GHOSTLY_THRALL",
       "LESSER_GHOSTLY_THRALL",
@@ -20224,15 +20224,15 @@
     "height": 80,
     "alignment": "CENTER",
     "radius": 400,
-    "strength": 15.0,
+    "strength": 15,
     "color": [
-      0.28445208,
-      0.91575015,
-      0.051122054
+      144,
+      245,
+      66
     ],
     "type": "FLICKER",
-    "duration": 0.0,
-    "range": 10.0,
+    "duration": 0,
+    "range": 10,
     "npcIds": [
       "LESSER_SKELETAL_THRALL",
       "SUPERIOR_SKELETAL_THRALL",
@@ -20244,15 +20244,15 @@
     "height": 80,
     "alignment": "CENTER",
     "radius": 400,
-    "strength": 15.0,
+    "strength": 15,
     "color": [
-      1.0,
-      0.0,
-      0.0
+      255,
+      0,
+      0
     ],
     "type": "FLICKER",
-    "duration": 0.0,
-    "range": 10.0,
+    "duration": 0,
+    "range": 10,
     "npcIds": [
       "LESSER_ZOMBIFIED_THRALL",
       "SUPERIOR_ZOMBIFIED_THRALL",
@@ -20264,15 +20264,15 @@
     "height": 180,
     "alignment": "CENTER",
     "radius": 900,
-    "strength": 15.0,
+    "strength": 15,
     "color": [
-      0.069727086,
-      0.0,
-      1.0
+      76,
+      0,
+      255
     ],
     "type": "PULSE",
-    "duration": 2400.0,
-    "range": 20.0,
+    "duration": 2400,
+    "range": 20,
     "npcIds": [
       "GLOWING_CRYSTAL"
     ]
@@ -20282,15 +20282,15 @@
     "height": 300,
     "alignment": "CENTER",
     "radius": 1200,
-    "strength": 15.0,
+    "strength": 15,
     "color": [
-      0.069727086,
-      0.0,
-      1.0
+      76,
+      0,
+      255
     ],
     "type": "PULSE",
-    "duration": 2400.0,
-    "range": 30.0,
+    "duration": 2400,
+    "range": 30,
     "npcIds": [
       "VASA_NISTIRIO",
       "VASA_NISTIRIO_7567"
@@ -20301,15 +20301,15 @@
     "height": 100,
     "alignment": "CENTER",
     "radius": 600,
-    "strength": 15.0,
+    "strength": 15,
     "color": [
-      1.0,
-      0.36859095,
-      0.017936433
+      255,
+      162,
+      41
     ],
     "type": "STATIC",
-    "duration": 2400.0,
-    "range": 0.0,
+    "duration": 2400,
+    "range": 0,
     "npcIds": [
       "TEKTON",
       "TEKTON_7541",
@@ -20322,15 +20322,15 @@
     "height": 100,
     "alignment": "CENTER",
     "radius": 600,
-    "strength": 20.0,
+    "strength": 20,
     "color": [
-      1.0,
-      0.113920934,
-      0.017936433
+      255,
+      95,
+      41
     ],
     "type": "STATIC",
-    "duration": 2400.0,
-    "range": 0.0,
+    "duration": 2400,
+    "range": 0,
     "npcIds": [
       "TEKTON_ENRAGED",
       "TEKTON_ENRAGED_7544"
@@ -20341,15 +20341,15 @@
     "height": 20,
     "alignment": "CENTER",
     "radius": 600,
-    "strength": 15.0,
+    "strength": 15,
     "color": [
-      1.0,
-      0.36859095,
-      0.017936433
+      255,
+      162,
+      41
     ],
     "type": "STATIC",
-    "duration": 2400.0,
-    "range": 0.0,
+    "duration": 2400,
+    "range": 0,
     "npcIds": [
       "VANGUARD",
       "VANGUARD_7526",
@@ -20363,15 +20363,15 @@
     "height": 60,
     "alignment": "CENTER",
     "radius": 300,
-    "strength": 15.0,
+    "strength": 15,
     "color": [
-      0.21951973,
-      1.0,
-      0.0
+      128,
+      255,
+      0
     ],
     "type": "PULSE",
-    "duration": 2400.0,
-    "range": 20.0,
+    "duration": 2400,
+    "range": 20,
     "npcIds": [
       "JEWELLED_CRAB_GREEN"
     ]
@@ -20381,15 +20381,15 @@
     "height": 60,
     "alignment": "CENTER",
     "radius": 300,
-    "strength": 15.0,
+    "strength": 15,
     "color": [
-      1.0,
-      0.0,
-      0.0
+      255,
+      0,
+      0
     ],
     "type": "PULSE",
-    "duration": 2400.0,
-    "range": 20.0,
+    "duration": 2400,
+    "range": 20,
     "npcIds": [
       "JEWELLED_CRAB_RED"
     ]
@@ -20399,15 +20399,15 @@
     "height": 60,
     "alignment": "CENTER",
     "radius": 300,
-    "strength": 15.0,
+    "strength": 15,
     "color": [
-      0.0,
-      1.0,
-      1.0
+      0,
+      255,
+      255
     ],
     "type": "PULSE",
-    "duration": 2400.0,
-    "range": 20.0,
+    "duration": 2400,
+    "range": 20,
     "npcIds": [
       "JEWELLED_CRAB_BLUE"
     ]
@@ -20417,15 +20417,15 @@
     "height": 100,
     "alignment": "CENTER",
     "radius": 1200,
-    "strength": 15.0,
+    "strength": 15,
     "color": [
-      1.0,
-      0.0,
-      0.38891026
+      255,
+      0,
+      166
     ],
     "type": "PULSE",
-    "duration": 1950.0,
-    "range": 20.0,
+    "duration": 1950,
+    "range": 20,
     "npcIds": [
       "THE_NIGHTMARE_9461",
       "THE_NIGHTMARE_9462",
@@ -20440,13 +20440,13 @@
     "radius": 400,
     "strength": 12.5,
     "color": [
-      1.0,
-      0.20471011,
-      0.0
+      255,
+      124,
+      0
     ],
     "type": "FLICKER",
-    "duration": 0.0,
-    "range": 20.0,
+    "duration": 0,
+    "range": 20,
     "npcIds": [
       "FIRE_GIANT_2080",
       "FIRE_GIANT_2081",
@@ -20467,15 +20467,15 @@
     "height": 120,
     "alignment": "CENTER",
     "radius": 400,
-    "strength": 15.0,
+    "strength": 15,
     "color": [
-      0.31118053,
-      0.06772459,
-      1.0
+      150,
+      75,
+      255
     ],
     "type": "PULSE",
-    "duration": 2000.0,
-    "range": 25.0,
+    "duration": 2000,
+    "range": 25,
     "npcIds": [
       "PORTAL_1747",
       "PORTAL_1751",
@@ -20490,13 +20490,13 @@
     "radius": 400,
     "strength": 12.5,
     "color": [
-      0.0,
-      0.43681276,
-      1.0
+      0,
+      175,
+      255
     ],
     "type": "PULSE",
-    "duration": 2000.0,
-    "range": 25.0,
+    "duration": 2000,
+    "range": 25,
     "npcIds": [
       "PORTAL_1744",
       "PORTAL_1748",
@@ -20511,13 +20511,13 @@
     "radius": 400,
     "strength": 12.5,
     "color": [
-      0.79691654,
-      1.0,
-      0.10114516
+      230,
+      255,
+      90
     ],
     "type": "PULSE",
-    "duration": 2000.0,
-    "range": 25.0,
+    "duration": 2000,
+    "range": 25,
     "npcIds": [
       "PORTAL_1745",
       "PORTAL_1749",
@@ -20532,13 +20532,13 @@
     "radius": 400,
     "strength": 12.5,
     "color": [
-      1.0,
-      0.0,
-      0.10114516
+      255,
+      0,
+      90
     ],
     "type": "PULSE",
-    "duration": 2000.0,
-    "range": 25.0,
+    "duration": 2000,
+    "range": 25,
     "npcIds": [
       "PORTAL_1746",
       "PORTAL_1750",
@@ -20553,13 +20553,13 @@
     "radius": 200,
     "strength": 7.5,
     "color": [
-      1.0,
-      0.0,
-      0.009021491
+      255,
+      0,
+      30
     ],
     "type": "PULSE",
-    "duration": 1500.0,
-    "range": 10.0,
+    "duration": 1500,
+    "range": 10,
     "npcIds": [
       "VOID_KNIGHT_2950",
       "VOID_KNIGHT_2951",
@@ -20574,13 +20574,13 @@
     "radius": 400,
     "strength": 12.5,
     "color": [
-      0.48195225,
-      0.8277258,
-      0.7592996
+      183,
+      234,
+      225
     ],
     "type": "PULSE",
-    "duration": 3400.0,
-    "range": 10.0,
+    "duration": 3400,
+    "range": 10,
     "npcIds": [
       "REVENANT_CYCLOPS"
     ]
@@ -20592,13 +20592,13 @@
     "radius": 200,
     "strength": 12.5,
     "color": [
-      0.48195225,
-      0.8277258,
-      0.7592996
+      183,
+      234,
+      225
     ],
     "type": "PULSE",
-    "duration": 3400.0,
-    "range": 10.0,
+    "duration": 3400,
+    "range": 10,
     "npcIds": [
       "REVENANT_IMP"
     ]
@@ -20610,13 +20610,13 @@
     "radius": 500,
     "strength": 12.5,
     "color": [
-      0.48195225,
-      0.8277258,
-      0.7592996
+      183,
+      234,
+      225
     ],
     "type": "PULSE",
-    "duration": 3400.0,
-    "range": 10.0,
+    "duration": 3400,
+    "range": 10,
     "npcIds": [
       "REVENANT_DEMON"
     ]
@@ -20628,13 +20628,13 @@
     "radius": 700,
     "strength": 12.5,
     "color": [
-      0.48195225,
-      0.8277258,
-      0.7592996
+      183,
+      234,
+      225
     ],
     "type": "PULSE",
-    "duration": 3400.0,
-    "range": 10.0,
+    "duration": 3400,
+    "range": 10,
     "npcIds": [
       "REVENANT_DRAGON"
     ]
@@ -20646,13 +20646,13 @@
     "radius": 300,
     "strength": 12.5,
     "color": [
-      0.48195225,
-      0.8277258,
-      0.7592996
+      183,
+      234,
+      225
     ],
     "type": "PULSE",
-    "duration": 3400.0,
-    "range": 10.0,
+    "duration": 3400,
+    "range": 10,
     "npcIds": [
       "REVENANT_GOBLIN"
     ]
@@ -20664,13 +20664,13 @@
     "radius": 600,
     "strength": 12.5,
     "color": [
-      0.48195225,
-      0.8277258,
-      0.7592996
+      183,
+      234,
+      225
     ],
     "type": "PULSE",
-    "duration": 3400.0,
-    "range": 10.0,
+    "duration": 3400,
+    "range": 10,
     "npcIds": [
       "REVENANT_DARK_BEAST"
     ]
@@ -20682,13 +20682,13 @@
     "radius": 200,
     "strength": 12.5,
     "color": [
-      0.48195225,
-      0.8277258,
-      0.7592996
+      183,
+      234,
+      225
     ],
     "type": "PULSE",
-    "duration": 3400.0,
-    "range": 10.0,
+    "duration": 3400,
+    "range": 10,
     "npcIds": [
       "REVENANT_HELLHOUND"
     ]
@@ -20700,13 +20700,13 @@
     "radius": 400,
     "strength": 12.5,
     "color": [
-      0.48195225,
-      0.8277258,
-      0.7592996
+      183,
+      234,
+      225
     ],
     "type": "PULSE",
-    "duration": 3400.0,
-    "range": 10.0,
+    "duration": 3400,
+    "range": 10,
     "npcIds": [
       "REVENANT_HOBGOBLIN"
     ]
@@ -20718,13 +20718,13 @@
     "radius": 400,
     "strength": 12.5,
     "color": [
-      0.48195225,
-      0.8277258,
-      0.7592996
+      183,
+      234,
+      225
     ],
     "type": "PULSE",
-    "duration": 3400.0,
-    "range": 10.0,
+    "duration": 3400,
+    "range": 10,
     "npcIds": [
       "REVENANT_KNIGHT"
     ]
@@ -20736,13 +20736,13 @@
     "radius": 400,
     "strength": 12.5,
     "color": [
-      0.48195225,
-      0.8277258,
-      0.7592996
+      183,
+      234,
+      225
     ],
     "type": "PULSE",
-    "duration": 3400.0,
-    "range": 10.0,
+    "duration": 3400,
+    "range": 10,
     "npcIds": [
       "REVENANT_ORK"
     ]
@@ -20754,13 +20754,13 @@
     "radius": 200,
     "strength": 12.5,
     "color": [
-      0.48195225,
-      0.8277258,
-      0.7592996
+      183,
+      234,
+      225
     ],
     "type": "PULSE",
-    "duration": 3400.0,
-    "range": 10.0,
+    "duration": 3400,
+    "range": 10,
     "npcIds": [
       "REVENANT_PYREFIEND"
     ]
@@ -20772,13 +20772,13 @@
     "radius": 500,
     "strength": 12.5,
     "color": [
-      0.9743002,
-      0.3021255,
-      5.6921755E-5
+      252,
+      148,
+      3
     ],
     "type": "FLICKER",
-    "duration": 0.0,
-    "range": 20.0,
+    "duration": 0,
+    "range": 20,
     "objectIds": [
       10720,
       "STANDING_TORCH_10178",
@@ -20810,13 +20810,13 @@
     "radius": 450,
     "strength": 12.5,
     "color": [
-      0.9743002,
-      0.3021255,
-      5.6921755E-5
+      252,
+      148,
+      3
     ],
     "type": "FLICKER",
-    "duration": 0.0,
-    "range": 20.0,
+    "duration": 0,
+    "range": 20,
     "objectIds": [
       "TORCH_38512",
       "TORCH_38513",
@@ -20837,13 +20837,13 @@
     "radius": 700,
     "strength": 12.5,
     "color": [
-      0.9743002,
-      0.3021255,
-      5.6921755E-5
+      252,
+      148,
+      3
     ],
     "type": "FLICKER",
-    "duration": 0.0,
-    "range": 20.0,
+    "duration": 0,
+    "range": 20,
     "objectIds": [
       "FIRE_25156"
     ]
@@ -20855,13 +20855,13 @@
     "radius": 700,
     "strength": 12.5,
     "color": [
-      0.9743002,
-      0.3021255,
-      5.6921755E-5
+      252,
+      148,
+      3
     ],
     "type": "FLICKER",
-    "duration": 0.0,
-    "range": 20.0,
+    "duration": 0,
+    "range": 20,
     "objectIds": [
       "BRAZIER_37826"
     ]
@@ -20873,13 +20873,13 @@
     "radius": 400,
     "strength": 12.5,
     "color": [
-      0.011881335,
-      0.020951131,
-      1.0
+      34,
+      44,
+      255
     ],
     "type": "FLICKER",
-    "duration": 0.0,
-    "range": 20.0,
+    "duration": 0,
+    "range": 20,
     "objectIds": [
       "TORCH_34856"
     ]
@@ -20891,13 +20891,13 @@
     "radius": 600,
     "strength": 12.5,
     "color": [
-      0.9743002,
-      0.3021255,
-      5.6921755E-5
+      252,
+      148,
+      3
     ],
     "type": "FLICKER",
-    "duration": 0.0,
-    "range": 20.0,
+    "duration": 0,
+    "range": 20,
     "objectIds": [
       "LAMP_6202"
     ]
@@ -20909,34 +20909,34 @@
     "radius": 300,
     "strength": 12.5,
     "color": [
-      0.9743002,
-      0.3021255,
-      5.6921755E-5
+      252,
+      148,
+      3
     ],
     "type": "FLICKER",
-    "duration": 0.0,
-    "range": 20.0,
+    "duration": 0,
+    "range": 20,
     "objectIds": [
       198,
       6537,
+      18891,
       12300,
       31628,
       12238,
       20942,
       3474,
-      4694,
-      5208,
-      10297,
-      15161,
-      25659,
-      5247,
-      18891,
       "GRAVE_43122",
       "GRAVE_43123",
       "GRAVE_43124",
       "GRAVE_43125",
+      4694,
       "GRAVE_43126",
-      43127
+      43127,
+      5208,
+      10297,
+      15161,
+      25659,
+      5247
     ]
   },
   {
@@ -20946,13 +20946,13 @@
     "radius": 300,
     "strength": 12.5,
     "color": [
-      0.9743002,
-      0.3021255,
-      5.6921755E-5
+      252,
+      148,
+      3
     ],
     "type": "FLICKER",
-    "duration": 0.0,
-    "range": 20.0,
+    "duration": 0,
+    "range": 20,
     "objectIds": [
       196,
       197,
@@ -20976,13 +20976,13 @@
     "radius": 300,
     "strength": 12.5,
     "color": [
-      0.9743002,
-      0.3021255,
-      5.6921755E-5
+      252,
+      148,
+      3
     ],
     "type": "FLICKER",
-    "duration": 0.0,
-    "range": 20.0,
+    "duration": 0,
+    "range": 20,
     "objectIds": [
       24173
     ]
@@ -20992,15 +20992,15 @@
     "height": 300,
     "alignment": "FRONT",
     "radius": 300,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      0.9743002,
-      0.3021255,
-      5.6921755E-5
+      252,
+      148,
+      3
     ],
     "type": "FLICKER",
-    "duration": 0.0,
-    "range": 20.0,
+    "duration": 0,
+    "range": 20,
     "objectIds": [
       9746,
       18355
@@ -21011,15 +21011,15 @@
     "height": 10,
     "alignment": "CENTER",
     "radius": 300,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      0.9743002,
-      0.3021255,
-      5.6921755E-5
+      252,
+      148,
+      3
     ],
     "type": "FLICKER",
-    "duration": 0.0,
-    "range": 20.0,
+    "duration": 0,
+    "range": 20,
     "objectIds": [
       "CANDLES_11472",
       "CANDLES_12301"
@@ -21030,15 +21030,15 @@
     "height": 10,
     "alignment": "BACK",
     "radius": 200,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      0.9743002,
-      0.3021255,
-      5.6921755E-5
+      252,
+      148,
+      3
     ],
     "type": "FLICKER",
-    "duration": 0.0,
-    "range": 20.0,
+    "duration": 0,
+    "range": 20,
     "objectIds": [
       "CANDLES_12302"
     ]
@@ -21050,20 +21050,20 @@
     "radius": 500,
     "strength": 12.5,
     "color": [
-      0.9743002,
-      0.3021255,
-      5.6921755E-5
+      252,
+      148,
+      3
     ],
     "type": "FLICKER",
-    "duration": 0.0,
-    "range": 20.0,
+    "duration": 0,
+    "range": 20,
     "objectIds": [
       4691,
       "LANTERN_10307",
       "LANTERN_16901",
+      23577,
       "LANTERN",
-      "LANTERN_11468",
-      23577
+      "LANTERN_11468"
     ]
   },
   {
@@ -21071,15 +21071,15 @@
     "height": 200,
     "alignment": "CENTER",
     "radius": 500,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      0.8355278,
-      0.14799802,
-      0.030256517
+      235,
+      107,
+      52
     ],
     "type": "FLICKER",
-    "duration": 0.0,
-    "range": 20.0,
+    "duration": 0,
+    "range": 20,
     "objectIds": [
       "LANTERN_42132",
       "LANTERN_42133",
@@ -21094,13 +21094,13 @@
     "radius": 1500,
     "strength": 12.5,
     "color": [
-      0.9743002,
-      0.3021255,
-      5.6921755E-5
+      252,
+      148,
+      3
     ],
     "type": "FLICKER",
-    "duration": 0.0,
-    "range": 20.0,
+    "duration": 0,
+    "range": 20,
     "objectIds": [
       "FIREPLACE_4650"
     ]
@@ -21112,13 +21112,13 @@
     "radius": 250,
     "strength": 12.5,
     "color": [
-      0.9743002,
-      0.3021255,
-      5.6921755E-5
+      252,
+      148,
+      3
     ],
     "type": "FLICKER",
-    "duration": 0.0,
-    "range": 20.0,
+    "duration": 0,
+    "range": 20,
     "objectIds": [
       "SPIT_ROAST_5608",
       "SPIT_ROAST"
@@ -21131,13 +21131,13 @@
     "radius": 250,
     "strength": 7.5,
     "color": [
-      0.9743002,
-      0.19751643,
-      5.6921755E-5
+      252,
+      122,
+      3
     ],
     "type": "FLICKER",
-    "duration": 0.0,
-    "range": 20.0,
+    "duration": 0,
+    "range": 20,
     "objectIds": [
       "COOKING_POT_26180"
     ]
@@ -21149,13 +21149,13 @@
     "radius": 450,
     "strength": 12.5,
     "color": [
-      0.9743002,
-      0.3021255,
-      5.6921755E-5
+      252,
+      148,
+      3
     ],
     "type": "FLICKER",
-    "duration": 0.0,
-    "range": 20.0,
+    "duration": 0,
+    "range": 20,
     "objectIds": [
       "FIRE_5249",
       "FIRE_30021",
@@ -21203,13 +21203,13 @@
     "radius": 800,
     "strength": 12.5,
     "color": [
-      0.9743002,
-      0.3021255,
-      5.6921755E-5
+      252,
+      148,
+      3
     ],
     "type": "FLICKER",
-    "duration": 0.0,
-    "range": 20.0,
+    "duration": 0,
+    "range": 20,
     "objectIds": [
       "FIRE_25155",
       "FIRE_35812",
@@ -21223,13 +21223,13 @@
     "radius": 450,
     "strength": 12.5,
     "color": [
-      0.36360392,
-      0.9743002,
-      5.6921755E-5
+      161,
+      252,
+      3
     ],
     "type": "FLICKER",
-    "duration": 0.0,
-    "range": 20.0,
+    "duration": 0,
+    "range": 20,
     "objectIds": [
       "MAGICAL_FIRE_37996"
     ]
@@ -21241,13 +21241,13 @@
     "radius": 800,
     "strength": 12.5,
     "color": [
-      0.36360392,
-      0.9743002,
-      5.6921755E-5
+      161,
+      252,
+      3
     ],
     "type": "FLICKER",
-    "duration": 0.0,
-    "range": 20.0,
+    "duration": 0,
+    "range": 20,
     "objectIds": [
       "MAGICAL_FIRE_37994",
       "MAGICAL_FIRE_37995"
@@ -21260,13 +21260,13 @@
     "radius": 800,
     "strength": 12.5,
     "color": [
-      0.9743002,
-      0.3021255,
-      5.6921755E-5
+      252,
+      148,
+      3
     ],
     "type": "FLICKER",
-    "duration": 0.0,
-    "range": 20.0,
+    "duration": 0,
+    "range": 20,
     "objectIds": [
       "MARBLE_FIREPLACE_6785",
       "FIREPLACE_26179",
@@ -21308,13 +21308,13 @@
     "radius": 450,
     "strength": 12.5,
     "color": [
-      0.9743002,
-      0.3021255,
-      5.6921755E-5
+      252,
+      148,
+      3
     ],
     "type": "FLICKER",
-    "duration": 0.0,
-    "range": 20.0,
+    "duration": 0,
+    "range": 20,
     "objectIds": [
       19135
     ]
@@ -21326,13 +21326,13 @@
     "radius": 400,
     "strength": 12.5,
     "color": [
-      0.9743002,
-      0.3021255,
-      5.6921755E-5
+      252,
+      148,
+      3
     ],
     "type": "FLICKER",
-    "duration": 0.0,
-    "range": 20.0,
+    "duration": 0,
+    "range": 20,
     "objectIds": [
       "BARRICADE_35806"
     ]
@@ -21344,13 +21344,13 @@
     "radius": 450,
     "strength": 12.5,
     "color": [
-      0.0,
-      0.72267246,
-      1.0
+      0,
+      220,
+      255
     ],
     "type": "FLICKER",
-    "duration": 0.0,
-    "range": 20.0,
+    "duration": 0,
+    "range": 20,
     "objectIds": [
       "TORCH_34345"
     ]
@@ -21362,13 +21362,13 @@
     "radius": 700,
     "strength": 12.5,
     "color": [
-      0.0,
-      0.72267246,
-      1.0
+      0,
+      220,
+      255
     ],
     "type": "FLICKER",
-    "duration": 0.0,
-    "range": 20.0,
+    "duration": 0,
+    "range": 20,
     "objectIds": [
       "STANDING_TORCH_34346"
     ]
@@ -21380,13 +21380,13 @@
     "radius": 450,
     "strength": 12.5,
     "color": [
-      0.19046287,
-      0.0055217445,
-      0.85125166
+      120,
+      24,
+      237
     ],
     "type": "FLICKER",
-    "duration": 0.0,
-    "range": 20.0,
+    "duration": 0,
+    "range": 20,
     "objectIds": [
       "FIRE_20001"
     ]
@@ -21398,13 +21398,13 @@
     "radius": 450,
     "strength": 12.5,
     "color": [
-      0.7372048,
-      0.0160677,
-      0.004559755
+      222,
+      39,
+      22
     ],
     "type": "FLICKER",
-    "duration": 0.0,
-    "range": 20.0,
+    "duration": 0,
+    "range": 20,
     "objectIds": [
       "FIRE_26186"
     ]
@@ -21416,13 +21416,13 @@
     "radius": 450,
     "strength": 12.5,
     "color": [
-      5.6921755E-5,
-      0.1869885,
-      0.9743002
+      3,
+      119,
+      252
     ],
     "type": "FLICKER",
-    "duration": 0.0,
-    "range": 20.0,
+    "duration": 0,
+    "range": 20,
     "objectIds": [
       "FIRE_26576"
     ]
@@ -21434,13 +21434,13 @@
     "radius": 450,
     "strength": 7.5,
     "color": [
-      1.0,
-      1.0,
-      1.0
+      255,
+      255,
+      255
     ],
     "type": "FLICKER",
-    "duration": 0.0,
-    "range": 20.0,
+    "duration": 0,
+    "range": 20,
     "objectIds": [
       "FIRE_20000"
     ]
@@ -21452,13 +21452,13 @@
     "radius": 450,
     "strength": 12.5,
     "color": [
-      0.05818718,
-      0.89126205,
-      0.009696328
+      70,
+      242,
+      31
     ],
     "type": "FLICKER",
-    "duration": 0.0,
-    "range": 20.0,
+    "duration": 0,
+    "range": 20,
     "objectIds": [
       "FIRE_26575"
     ]
@@ -21468,15 +21468,15 @@
     "height": 270,
     "alignment": "CENTER",
     "radius": 450,
-    "strength": 15.0,
+    "strength": 15,
     "color": [
-      0.585973,
-      0.72267246,
-      1.0
+      200,
+      220,
+      255
     ],
     "type": "STATIC",
-    "duration": 0.0,
-    "range": 0.0,
+    "duration": 0,
+    "range": 0,
     "objectIds": [
       "CLIMBING_ROPE_18967",
       "CLIMBING_ROPE_18968",
@@ -21491,13 +21491,13 @@
     "radius": 700,
     "strength": 6.3,
     "color": [
-      0.9743002,
-      0.63877946,
-      0.13902245
+      252,
+      208,
+      104
     ],
     "type": "FLICKER",
-    "duration": 0.0,
-    "range": 30.0,
+    "duration": 0,
+    "range": 30,
     "objectIds": [
       25056,
       17829,
@@ -21511,13 +21511,13 @@
     "radius": 500,
     "strength": 7.5,
     "color": [
-      1.0,
-      0.02775528,
-      0.0
+      255,
+      50,
+      0
     ],
     "type": "STATIC",
-    "duration": 0.0,
-    "range": 0.0,
+    "duration": 0,
+    "range": 0,
     "objectIds": [
       "MUSHROOM_TORCH"
     ]
@@ -21529,13 +21529,13 @@
     "radius": 500,
     "strength": 7.5,
     "color": [
-      0.0,
-      0.31118053,
-      1.0
+      0,
+      150,
+      255
     ],
     "type": "STATIC",
-    "duration": 0.0,
-    "range": 0.0,
+    "duration": 0,
+    "range": 0,
     "objectIds": [
       "MUSHROOM_TORCH_12006"
     ]
@@ -21547,13 +21547,13 @@
     "radius": 800,
     "strength": 7.5,
     "color": [
-      0.9743002,
-      0.10114516,
-      5.6921755E-5
+      252,
+      90,
+      3
     ],
     "type": "FLICKER",
-    "duration": 0.0,
-    "range": 10.0,
+    "duration": 0,
+    "range": 10,
     "objectIds": [
       12101,
       24012
@@ -21566,13 +21566,13 @@
     "radius": 800,
     "strength": 7.5,
     "color": [
-      0.9743002,
-      0.10114516,
-      5.6921755E-5
+      252,
+      90,
+      3
     ],
     "type": "FLICKER",
-    "duration": 0.0,
-    "range": 10.0,
+    "duration": 0,
+    "range": 10,
     "objectIds": [
       12805
     ]
@@ -21584,13 +21584,13 @@
     "radius": 700,
     "strength": 8.8,
     "color": [
-      0.9743002,
-      0.3021255,
-      5.6921755E-5
+      252,
+      148,
+      3
     ],
     "type": "FLICKER",
-    "duration": 0.0,
-    "range": 30.0,
+    "duration": 0,
+    "range": 30,
     "objectIds": [
       "FURNACE_16657",
       "FURNACE_16469"
@@ -21601,15 +21601,15 @@
     "height": 300,
     "alignment": "CENTER",
     "radius": 1800,
-    "strength": 12.0,
+    "strength": 12,
     "color": [
-      0.14497213,
-      1.0,
-      0.13035227
+      106,
+      255,
+      101
     ],
     "type": "PULSE",
-    "duration": 4000.0,
-    "range": 15.0,
+    "duration": 4000,
+    "range": 15,
     "objectIds": [
       "ECTOFUNTUS"
     ]
@@ -21622,15 +21622,15 @@
     "height": 100,
     "alignment": "CENTER",
     "radius": 3500,
-    "strength": 1.0,
+    "strength": 1,
     "color": [
-      0.28,
-      1.0,
-      0.255
+      142.97115,
+      255,
+      137.02055
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -21641,15 +21641,15 @@
     "height": 100,
     "alignment": "CENTER",
     "radius": 3500,
-    "strength": 1.0,
+    "strength": 1,
     "color": [
-      0.28,
-      1.0,
-      0.255
+      142.97115,
+      255,
+      137.02055
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -21660,15 +21660,15 @@
     "height": 100,
     "alignment": "CENTER",
     "radius": 3500,
-    "strength": 1.0,
+    "strength": 1,
     "color": [
-      0.28,
-      1.0,
-      0.255
+      142.97115,
+      255,
+      137.02055
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -21679,15 +21679,15 @@
     "height": 100,
     "alignment": "CENTER",
     "radius": 3500,
-    "strength": 1.0,
+    "strength": 1,
     "color": [
-      0.28,
-      1.0,
-      0.255
+      142.97115,
+      255,
+      137.02055
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -21698,15 +21698,15 @@
     "height": 100,
     "alignment": "CENTER",
     "radius": 3500,
-    "strength": 1.0,
+    "strength": 1,
     "color": [
-      0.28,
-      1.0,
-      0.255
+      142.97115,
+      255,
+      137.02055
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -21717,15 +21717,15 @@
     "height": 100,
     "alignment": "CENTER",
     "radius": 3500,
-    "strength": 1.0,
+    "strength": 1,
     "color": [
-      0.28,
-      1.0,
-      0.255
+      142.97115,
+      255,
+      137.02055
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -21736,15 +21736,15 @@
     "height": 100,
     "alignment": "CENTER",
     "radius": 3500,
-    "strength": 1.0,
+    "strength": 1,
     "color": [
-      0.28,
-      1.0,
-      0.255
+      142.97115,
+      255,
+      137.02055
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -21752,15 +21752,15 @@
     "height": 100,
     "alignment": "CENTER",
     "radius": 500,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      0.14497213,
-      1.0,
-      0.13035227
+      106,
+      255,
+      101
     ],
     "type": "PULSE",
-    "duration": 4000.0,
-    "range": 15.0,
+    "duration": 4000,
+    "range": 15,
     "objectIds": [
       "ECTOFUNTUS_16649"
     ]
@@ -21773,15 +21773,15 @@
     "height": 150,
     "alignment": "CENTER",
     "radius": 800,
-    "strength": 2.0,
+    "strength": 2,
     "color": [
-      0.4,
-      1.0,
-      0.4
+      168.1351,
+      255,
+      168.1351
     ],
     "type": "PULSE",
-    "duration": 4000.0,
-    "range": 5.0,
+    "duration": 4000,
+    "range": 5,
     "fadeInDuration": 0
   },
   {
@@ -21792,15 +21792,15 @@
     "height": 150,
     "alignment": "CENTER",
     "radius": 800,
-    "strength": 2.0,
+    "strength": 2,
     "color": [
-      0.4,
-      1.0,
-      0.4
+      168.1351,
+      255,
+      168.1351
     ],
     "type": "PULSE",
-    "duration": 4000.0,
-    "range": 5.0,
+    "duration": 4000,
+    "range": 5,
     "fadeInDuration": 0
   },
   {
@@ -21811,15 +21811,15 @@
     "height": 150,
     "alignment": "CENTER",
     "radius": 800,
-    "strength": 2.0,
+    "strength": 2,
     "color": [
-      0.4,
-      1.0,
-      0.4
+      168.1351,
+      255,
+      168.1351
     ],
     "type": "PULSE",
-    "duration": 4000.0,
-    "range": 5.0,
+    "duration": 4000,
+    "range": 5,
     "fadeInDuration": 0
   },
   {
@@ -21830,15 +21830,15 @@
     "height": 150,
     "alignment": "CENTER",
     "radius": 800,
-    "strength": 2.0,
+    "strength": 2,
     "color": [
-      0.4,
-      1.0,
-      0.4
+      168.1351,
+      255,
+      168.1351
     ],
     "type": "PULSE",
-    "duration": 4000.0,
-    "range": 5.0,
+    "duration": 4000,
+    "range": 5,
     "fadeInDuration": 0
   },
   {
@@ -21849,15 +21849,15 @@
     "height": 150,
     "alignment": "CENTER",
     "radius": 800,
-    "strength": 2.0,
+    "strength": 2,
     "color": [
-      0.4,
-      1.0,
-      0.4
+      168.1351,
+      255,
+      168.1351
     ],
     "type": "PULSE",
-    "duration": 4000.0,
-    "range": 5.0,
+    "duration": 4000,
+    "range": 5,
     "fadeInDuration": 0
   },
   {
@@ -21868,15 +21868,15 @@
     "height": 150,
     "alignment": "CENTER",
     "radius": 800,
-    "strength": 2.0,
+    "strength": 2,
     "color": [
-      0.4,
-      1.0,
-      0.4
+      168.1351,
+      255,
+      168.1351
     ],
     "type": "PULSE",
-    "duration": 4000.0,
-    "range": 5.0,
+    "duration": 4000,
+    "range": 5,
     "fadeInDuration": 0
   },
   {
@@ -21887,15 +21887,15 @@
     "height": 150,
     "alignment": "CENTER",
     "radius": 800,
-    "strength": 2.0,
+    "strength": 2,
     "color": [
-      0.4,
-      1.0,
-      0.4
+      168.1351,
+      255,
+      168.1351
     ],
     "type": "PULSE",
-    "duration": 4000.0,
-    "range": 5.0,
+    "duration": 4000,
+    "range": 5,
     "fadeInDuration": 0
   },
   {
@@ -21906,15 +21906,15 @@
     "height": 150,
     "alignment": "CENTER",
     "radius": 800,
-    "strength": 2.0,
+    "strength": 2,
     "color": [
-      0.4,
-      1.0,
-      0.4
+      168.1351,
+      255,
+      168.1351
     ],
     "type": "PULSE",
-    "duration": 4000.0,
-    "range": 5.0,
+    "duration": 4000,
+    "range": 5,
     "fadeInDuration": 0
   },
   {
@@ -21925,15 +21925,15 @@
     "height": 150,
     "alignment": "CENTER",
     "radius": 800,
-    "strength": 2.0,
+    "strength": 2,
     "color": [
-      0.4,
-      1.0,
-      0.4
+      168.1351,
+      255,
+      168.1351
     ],
     "type": "PULSE",
-    "duration": 4000.0,
-    "range": 5.0,
+    "duration": 4000,
+    "range": 5,
     "fadeInDuration": 0
   },
   {
@@ -21944,15 +21944,15 @@
     "height": 150,
     "alignment": "CENTER",
     "radius": 800,
-    "strength": 2.0,
+    "strength": 2,
     "color": [
-      0.4,
-      1.0,
-      0.4
+      168.1351,
+      255,
+      168.1351
     ],
     "type": "PULSE",
-    "duration": 4000.0,
-    "range": 5.0,
+    "duration": 4000,
+    "range": 5,
     "fadeInDuration": 0
   },
   {
@@ -21963,15 +21963,15 @@
     "height": 150,
     "alignment": "CENTER",
     "radius": 800,
-    "strength": 2.0,
+    "strength": 2,
     "color": [
-      0.4,
-      1.0,
-      0.4
+      168.1351,
+      255,
+      168.1351
     ],
     "type": "PULSE",
-    "duration": 4000.0,
-    "range": 5.0,
+    "duration": 4000,
+    "range": 5,
     "fadeInDuration": 0
   },
   {
@@ -21982,15 +21982,15 @@
     "height": 150,
     "alignment": "CENTER",
     "radius": 800,
-    "strength": 2.0,
+    "strength": 2,
     "color": [
-      0.4,
-      1.0,
-      0.4
+      168.1351,
+      255,
+      168.1351
     ],
     "type": "PULSE",
-    "duration": 4000.0,
-    "range": 5.0,
+    "duration": 4000,
+    "range": 5,
     "fadeInDuration": 0
   },
   {
@@ -22000,13 +22000,13 @@
     "radius": 900,
     "strength": 8.3,
     "color": [
-      1.0,
-      0.31118053,
-      0.12752977
+      255,
+      150,
+      100
     ],
     "type": "STATIC",
-    "duration": 0.0,
-    "range": 0.0,
+    "duration": 0,
+    "range": 0,
     "objectIds": [
       "SARCOPHAGUS_20720",
       "SARCOPHAGUS_20721",
@@ -22023,13 +22023,13 @@
     "radius": 650,
     "strength": 12.5,
     "color": [
-      0.9743002,
-      0.3021255,
-      5.6921755E-5
+      252,
+      148,
+      3
     ],
     "type": "FLICKER",
-    "duration": 0.0,
-    "range": 20.0,
+    "duration": 0,
+    "range": 20,
     "objectIds": [
       "HEARTH"
     ]
@@ -22041,13 +22041,13 @@
     "radius": 250,
     "strength": 7.5,
     "color": [
-      0.9743002,
-      0.585973,
-      5.6921755E-5
+      252,
+      200,
+      3
     ],
     "type": "FLICKER",
-    "duration": 0.0,
-    "range": 20.0,
+    "duration": 0,
+    "range": 20,
     "objectIds": [
       "TABLE_6197",
       "TABLE_6199",
@@ -22059,15 +22059,15 @@
     "height": 80,
     "alignment": "CENTER",
     "radius": 600,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      0.5604992,
-      0.075926125,
-      0.44787085
+      196,
+      79,
+      177
     ],
     "type": "STATIC",
-    "duration": 0.0,
-    "range": 0.0,
+    "duration": 0,
+    "range": 0,
     "objectIds": [
       "CHAOS_RIFT_26765"
     ]
@@ -22079,13 +22079,13 @@
     "radius": 350,
     "strength": 12.5,
     "color": [
-      0.9743002,
-      0.3021255,
-      5.6921755E-5
+      252,
+      148,
+      3
     ],
     "type": "FLICKER",
-    "duration": 0.0,
-    "range": 20.0,
+    "duration": 0,
+    "range": 20,
     "objectIds": [
       11909
     ]
@@ -22095,15 +22095,15 @@
     "height": 50,
     "alignment": "CENTER",
     "radius": 300,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      1.0,
-      0.02775528,
-      0.0
+      255,
+      50,
+      0
     ],
     "type": "PULSE",
-    "duration": 1550.0,
-    "range": 20.0,
+    "duration": 1550,
+    "range": 20,
     "objectIds": [
       "ENERGY_BARRIER_4470"
     ]
@@ -22113,15 +22113,15 @@
     "height": 50,
     "alignment": "CENTER",
     "radius": 300,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      0.0,
-      0.07805659,
-      1.0
+      0,
+      80,
+      255
     ],
     "type": "PULSE",
-    "duration": 1550.0,
-    "range": 20.0,
+    "duration": 1550,
+    "range": 20,
     "objectIds": [
       "ENERGY_BARRIER"
     ]
@@ -22131,15 +22131,15 @@
     "height": 100,
     "alignment": "CENTER",
     "radius": 500,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      1.0,
-      0.02775528,
-      0.0
+      255,
+      50,
+      0
     ],
     "type": "PULSE",
-    "duration": 1550.0,
-    "range": 20.0,
+    "duration": 1550,
+    "range": 20,
     "objectIds": [
       "ZAMORAK_PORTAL",
       "PORTAL_4390",
@@ -22153,13 +22153,13 @@
     "radius": 500,
     "strength": 12.5,
     "color": [
-      0.0,
-      0.07805659,
-      1.0
+      0,
+      80,
+      255
     ],
     "type": "PULSE",
-    "duration": 1550.0,
-    "range": 20.0,
+    "duration": 1550,
+    "range": 20,
     "objectIds": [
       "SARADOMIN_PORTAL",
       "PORTAL_4389"
@@ -22172,13 +22172,13 @@
     "radius": 500,
     "strength": 7.5,
     "color": [
-      0.0,
-      1.0,
-      0.19046287
+      0,
+      255,
+      120
     ],
     "type": "PULSE",
-    "duration": 1550.0,
-    "range": 20.0,
+    "duration": 1550,
+    "range": 20,
     "objectIds": [
       "GUTHIX_PORTAL"
     ]
@@ -22188,15 +22188,15 @@
     "height": 70,
     "alignment": "CENTER",
     "radius": 400,
-    "strength": 15.0,
+    "strength": 15,
     "color": [
-      0.0,
-      0.07805659,
-      1.0
+      0,
+      80,
+      255
     ],
     "type": "PULSE",
-    "duration": 1600.0,
-    "range": 20.0,
+    "duration": 1600,
+    "range": 20,
     "objectIds": [
       "BLUE_BARRIER_40454"
     ]
@@ -22206,15 +22206,15 @@
     "height": 70,
     "alignment": "CENTER",
     "radius": 400,
-    "strength": 15.0,
+    "strength": 15,
     "color": [
-      1.0,
-      0.02775528,
-      0.0
+      255,
+      50,
+      0
     ],
     "type": "PULSE",
-    "duration": 1600.0,
-    "range": 20.0,
+    "duration": 1600,
+    "range": 20,
     "objectIds": [
       "RED_BARRIER_40456",
       "RED_BARRIER_40457"
@@ -22225,15 +22225,15 @@
     "height": 70,
     "alignment": "CENTER",
     "radius": 400,
-    "strength": 15.0,
+    "strength": 15,
     "color": [
-      1.0,
-      0.0,
-      1.0
+      255,
+      0,
+      255
     ],
     "type": "PULSE",
-    "duration": 1600.0,
-    "range": 20.0,
+    "duration": 1600,
+    "range": 20,
     "objectIds": [
       "BARRIER_41200"
     ]
@@ -22243,15 +22243,15 @@
     "height": 70,
     "alignment": "CENTER",
     "radius": 400,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      1.0,
-      1.0,
-      1.0
+      255,
+      255,
+      255
     ],
     "type": "PULSE",
-    "duration": 1600.0,
-    "range": 20.0,
+    "duration": 1600,
+    "range": 20,
     "objectIds": [
       "BARRIER_41199"
     ]
@@ -22261,15 +22261,15 @@
     "height": 120,
     "alignment": "CENTER",
     "radius": 700,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      1.0,
-      0.72267246,
-      0.023103556
+      255,
+      220,
+      46
     ],
     "type": "PULSE",
-    "duration": 1000.0,
-    "range": 20.0,
+    "duration": 1000,
+    "range": 20,
     "objectIds": [
       "SOUL_WARS_PORTAL",
       "PORTAL_40476"
@@ -22280,15 +22280,15 @@
     "height": 120,
     "alignment": "CENTER",
     "radius": 700,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      0.0,
-      0.07805659,
-      1.0
+      0,
+      80,
+      255
     ],
     "type": "PULSE",
-    "duration": 1000.0,
-    "range": 20.0,
+    "duration": 1000,
+    "range": 20,
     "objectIds": [
       "PORTAL_40460"
     ]
@@ -22298,15 +22298,15 @@
     "height": 120,
     "alignment": "CENTER",
     "radius": 700,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      1.0,
-      0.02775528,
-      0.0
+      255,
+      50,
+      0
     ],
     "type": "PULSE",
-    "duration": 1000.0,
-    "range": 20.0,
+    "duration": 1000,
+    "range": 20,
     "objectIds": [
       "PORTAL_40461"
     ]
@@ -22316,15 +22316,15 @@
     "height": 190,
     "alignment": "CENTER",
     "radius": 700,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      1.0,
-      0.72267246,
-      0.023103556
+      255,
+      220,
+      46
     ],
     "type": "PULSE",
-    "duration": 1000.0,
-    "range": 20.0,
+    "duration": 1000,
+    "range": 20,
     "objectIds": [
       "SOUL_WARS_PORTAL_40475"
     ]
@@ -22336,13 +22336,13 @@
     "radius": 700,
     "strength": 6.3,
     "color": [
-      0.9743002,
-      0.3021255,
-      5.6921755E-5
+      252,
+      148,
+      3
     ],
     "type": "FLICKER",
-    "duration": 0.0,
-    "range": 30.0,
+    "duration": 0,
+    "range": 30,
     "objectIds": [
       "TORCH_40550",
       "TORCH_40551"
@@ -22355,13 +22355,13 @@
     "radius": 900,
     "strength": 12.5,
     "color": [
-      0.9743002,
-      1.0,
-      1.0
+      252,
+      255,
+      255
     ],
     "type": "PULSE",
-    "duration": 1000.0,
-    "range": 30.0,
+    "duration": 1000,
+    "range": 30,
     "objectIds": [
       "SOUL_OBELISK_40449",
       40765
@@ -22374,13 +22374,13 @@
     "radius": 900,
     "strength": 12.5,
     "color": [
-      1.0,
-      0.02775528,
-      0.0
+      255,
+      50,
+      0
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 30.0,
+    "duration": 3000,
+    "range": 30,
     "objectIds": [
       "SOUL_OBELISK_40451"
     ]
@@ -22390,15 +22390,15 @@
     "height": 180,
     "alignment": "CENTER",
     "radius": 900,
-    "strength": 25.0,
+    "strength": 25,
     "color": [
-      0.0,
-      0.19046287,
-      1.0
+      0,
+      120,
+      255
     ],
     "type": "PULSE",
-    "duration": 3000.0,
-    "range": 30.0,
+    "duration": 3000,
+    "range": 30,
     "objectIds": [
       "SOUL_OBELISK_40450"
     ]
@@ -22408,15 +22408,15 @@
     "height": 120,
     "alignment": "CENTER",
     "radius": 600,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      0.0,
-      1.0,
-      0.25084025
+      0,
+      255,
+      136
     ],
     "type": "PULSE",
-    "duration": 1550.0,
-    "range": 20.0,
+    "duration": 1550,
+    "range": 20,
     "objectIds": [
       "CASTLE_WARS_PORTAL"
     ]
@@ -22426,15 +22426,15 @@
     "height": 100,
     "alignment": "CENTER",
     "radius": 400,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      0.0,
-      1.0,
-      0.25084025
+      0,
+      255,
+      136
     ],
     "type": "PULSE",
-    "duration": 1600.0,
-    "range": 20.0,
+    "duration": 1600,
+    "range": 20,
     "objectIds": [
       "COMPETITIVE"
     ]
@@ -22444,15 +22444,15 @@
     "height": 100,
     "alignment": "CENTER",
     "radius": 400,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      0.0,
-      1.0,
-      0.19046287
+      0,
+      255,
+      120
     ],
     "type": "PULSE",
-    "duration": 1500.0,
-    "range": 20.0,
+    "duration": 1500,
+    "range": 20,
     "objectIds": [
       "CASUAL"
     ]
@@ -22462,15 +22462,15 @@
     "height": 100,
     "alignment": "CENTER",
     "radius": 400,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      1.0,
-      0.02775528,
-      0.0
+      255,
+      50,
+      0
     ],
     "type": "PULSE",
-    "duration": 2050.0,
-    "range": 20.0,
+    "duration": 2050,
+    "range": 20,
     "objectIds": [
       39656
     ]
@@ -22480,15 +22480,15 @@
     "height": 180,
     "alignment": "CENTER",
     "radius": 600,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      0.20109573,
-      0.0,
-      1.0
+      123,
+      0,
+      255
     ],
     "type": "PULSE",
-    "duration": 1750.0,
-    "range": 20.0,
+    "duration": 1750,
+    "range": 20,
     "objectIds": [
       "CHALLENGE_PORTAL"
     ]
@@ -22498,15 +22498,15 @@
     "height": 120,
     "alignment": "CENTER",
     "radius": 600,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      1.0,
-      1.0,
-      1.0
+      255,
+      255,
+      255
     ],
     "type": "PULSE",
-    "duration": 1850.0,
-    "range": 20.0,
+    "duration": 1850,
+    "range": 20,
     "objectIds": [
       "FREEFORALL_PORTAL"
     ]
@@ -22516,15 +22516,15 @@
     "height": 180,
     "alignment": "CENTER",
     "radius": 900,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      1.0,
-      1.0,
-      1.0
+      255,
+      255,
+      255
     ],
     "type": "PULSE",
-    "duration": 1850.0,
-    "range": 20.0,
+    "duration": 1850,
+    "range": 20,
     "objectIds": [
       "PORTAL_26646"
     ]
@@ -22534,15 +22534,15 @@
     "height": 150,
     "alignment": "CENTER",
     "radius": 400,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      0.009696328,
-      0.7592996,
-      1.0
+      31,
+      225,
+      255
     ],
     "type": "PULSE",
-    "duration": 1250.0,
-    "range": 20.0,
+    "duration": 1250,
+    "range": 20,
     "objectIds": [
       "POOL_OF_REFRESHMENT"
     ]
@@ -22554,13 +22554,13 @@
     "radius": 550,
     "strength": 6.3,
     "color": [
-      0.0,
-      1.0,
-      0.19046287
+      0,
+      255,
+      120
     ],
     "type": "FLICKER",
-    "duration": 0.0,
-    "range": 30.0,
+    "duration": 0,
+    "range": 30,
     "objectIds": [
       39694
     ]
@@ -22570,15 +22570,15 @@
     "height": 500,
     "alignment": "SOUTH",
     "radius": 1500,
-    "strength": 15.0,
+    "strength": 15,
     "color": [
-      0.38377467,
-      1.0,
-      0.035614368
+      165,
+      255,
+      56
     ],
     "type": "STATIC",
-    "duration": 0.0,
-    "range": 0.0,
+    "duration": 0,
+    "range": 0,
     "objectIds": [
       "DOORS_OF_DINH"
     ]
@@ -22588,15 +22588,15 @@
     "height": 250,
     "alignment": "CENTER",
     "radius": 600,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      0.07176145,
-      0.0014331344,
-      1.0
+      77,
+      13,
+      255
     ],
     "type": "FLICKER",
-    "duration": 0.0,
-    "range": 10.0,
+    "duration": 0,
+    "range": 10,
     "objectIds": [
       39582
     ]
@@ -22606,15 +22606,15 @@
     "height": 250,
     "alignment": "CENTER",
     "radius": 1200,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      0.07176145,
-      0.0014331344,
-      1.0
+      77,
+      13,
+      255
     ],
     "type": "FLICKER",
-    "duration": 0.0,
-    "range": 10.0,
+    "duration": 0,
+    "range": 10,
     "objectIds": [
       39551
     ]
@@ -22624,15 +22624,15 @@
     "height": 180,
     "alignment": "WEST",
     "radius": 800,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      0.07176145,
-      0.0014331344,
-      1.0
+      77,
+      13,
+      255
     ],
     "type": "PULSE",
-    "duration": 1850.0,
-    "range": 20.0,
+    "duration": 1850,
+    "range": 20,
     "objectIds": [
       "PORTAL_39549"
     ]
@@ -22642,15 +22642,15 @@
     "height": 100,
     "alignment": "CENTER",
     "radius": 800,
-    "strength": 25.0,
+    "strength": 25,
     "color": [
-      0.87513757,
-      0.12752977,
-      0.0
+      240,
+      100,
+      0
     ],
     "type": "STATIC",
-    "duration": 0.0,
-    "range": 0.0,
+    "duration": 0,
+    "range": 0,
     "objectIds": [
       "CAVE_ENTRANCE_11833",
       "CAVE_ENTRANCE_11834"
@@ -22661,15 +22661,15 @@
     "height": 100,
     "alignment": "CENTER",
     "radius": 1400,
-    "strength": 15.0,
+    "strength": 15,
     "color": [
-      1.0,
-      0.585973,
-      0.10114516
+      255,
+      200,
+      90
     ],
     "type": "STATIC",
-    "duration": 0.0,
-    "range": 0.0,
+    "duration": 0,
+    "range": 0,
     "objectIds": [
       "CAVE_EXIT_11836"
     ]
@@ -22679,15 +22679,15 @@
     "height": -100,
     "alignment": "CENTER",
     "radius": 2000,
-    "strength": 25.0,
+    "strength": 25,
     "color": [
-      1.0,
-      0.034230206,
-      0.0
+      255,
+      55,
+      0
     ],
     "type": "STATIC",
-    "duration": 0.0,
-    "range": 0.0,
+    "duration": 0,
+    "range": 0,
     "objectIds": [
       30352
     ]
@@ -22697,15 +22697,15 @@
     "height": 160,
     "alignment": "CENTER",
     "radius": 700,
-    "strength": 15.0,
+    "strength": 15,
     "color": [
-      0.10871115,
-      0.0,
-      1.0
+      93,
+      0,
+      255
     ],
     "type": "PULSE",
-    "duration": 4100.0,
-    "range": 20.0,
+    "duration": 4100,
+    "range": 20,
     "objectIds": [
       "PORTAL_4525"
     ]
@@ -22715,15 +22715,15 @@
     "height": 180,
     "alignment": "CENTER",
     "radius": 700,
-    "strength": 15.0,
+    "strength": 15,
     "color": [
-      0.10871115,
-      0.0,
-      1.0
+      93,
+      0,
+      255
     ],
     "type": "PULSE",
-    "duration": 4100.0,
-    "range": 20.0,
+    "duration": 4100,
+    "range": 20,
     "objectIds": [
       "PORTAL_15477",
       "PORTAL_15478",
@@ -22739,15 +22739,15 @@
     "height": 120,
     "alignment": "CENTER",
     "radius": 700,
-    "strength": 15.0,
+    "strength": 15,
     "color": [
-      0.10871115,
-      0.0,
-      1.0
+      93,
+      0,
+      255
     ],
     "type": "PULSE",
-    "duration": 4100.0,
-    "range": 20.0,
+    "duration": 4100,
+    "range": 20,
     "objectIds": [
       "PORTAL_34947"
     ]
@@ -22759,13 +22759,13 @@
     "radius": 400,
     "strength": 12.5,
     "color": [
-      0.009696328,
-      0.7592996,
-      1.0
+      31,
+      225,
+      255
     ],
     "type": "PULSE",
-    "duration": 1250.0,
-    "range": 20.0,
+    "duration": 1250,
+    "range": 20,
     "objectIds": [
       "PORTAL_NEXUS_33354",
       "PORTAL_NEXUS_33355",
@@ -22876,15 +22876,15 @@
     "height": 150,
     "alignment": "CENTER",
     "radius": 400,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      1.0,
-      0.0,
-      0.08919351
+      255,
+      0,
+      85
     ],
     "type": "PULSE",
-    "duration": 1250.0,
-    "range": 20.0,
+    "duration": 1250,
+    "range": 20,
     "objectIds": [
       "POOL_OF_RESTORATION",
       "FROZEN_POOL_OF_RESTORATION"
@@ -22895,15 +22895,15 @@
     "height": 150,
     "alignment": "CENTER",
     "radius": 400,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      1.0,
-      0.45907992,
-      0.0
+      255,
+      179,
+      0
     ],
     "type": "PULSE",
-    "duration": 1250.0,
-    "range": 20.0,
+    "duration": 1250,
+    "range": 20,
     "objectIds": [
       "POOL_OF_REVITALISATION",
       "FROZEN_POOL_OF_REVITALISATION"
@@ -22914,15 +22914,15 @@
     "height": 150,
     "alignment": "CENTER",
     "radius": 400,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      0.009696328,
-      0.7592996,
-      1.0
+      31,
+      225,
+      255
     ],
     "type": "PULSE",
-    "duration": 1250.0,
-    "range": 20.0,
+    "duration": 1250,
+    "range": 20,
     "objectIds": [
       "POOL_OF_REJUVENATION",
       "FROZEN_POOL_OF_REJUVENATION"
@@ -22933,15 +22933,15 @@
     "height": 150,
     "alignment": "CENTER",
     "radius": 400,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      1.0,
-      0.0,
-      0.45907992
+      255,
+      0,
+      179
     ],
     "type": "PULSE",
-    "duration": 1250.0,
-    "range": 20.0,
+    "duration": 1250,
+    "range": 20,
     "objectIds": [
       "FANCY_POOL_OF_REJUVENATION",
       "FROZEN_FANCY_POOL_OF_REJUVENATION"
@@ -22952,15 +22952,15 @@
     "height": 150,
     "alignment": "CENTER",
     "radius": 400,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      0.28445208,
-      0.0,
-      1.0
+      144,
+      0,
+      255
     ],
     "type": "PULSE",
-    "duration": 1250.0,
-    "range": 20.0,
+    "duration": 1250,
+    "range": 20,
     "objectIds": [
       "FROZEN_ORNATE_POOL_OF_REJUVENATION",
       "ORNATE_POOL_OF_REJUVENATION"
@@ -22973,13 +22973,13 @@
     "radius": 400,
     "strength": 12.5,
     "color": [
-      0.28445208,
-      0.0,
-      1.0
+      144,
+      0,
+      255
     ],
     "type": "PULSE",
-    "duration": 4100.0,
-    "range": 20.0,
+    "duration": 4100,
+    "range": 20,
     "objectIds": [
       "SCRYING_POOL",
       "TELEPORTATION_FOCUS",
@@ -22993,13 +22993,13 @@
     "radius": 400,
     "strength": 12.5,
     "color": [
-      0.8355278,
-      0.27157745,
-      0.19751643
+      235,
+      141,
+      122
     ],
     "type": "PULSE",
-    "duration": 4100.0,
-    "range": 20.0,
+    "duration": 4100,
+    "range": 20,
     "objectIds": [
       "ARCEUUS_LIBRARY_PORTAL",
       "ARCEUUS_LIBRARY_PORTAL_41417",
@@ -23013,13 +23013,13 @@
     "radius": 400,
     "strength": 12.5,
     "color": [
-      0.42050794,
-      1.0,
-      0.07176145
+      172,
+      255,
+      77
     ],
     "type": "PULSE",
-    "duration": 4100.0,
-    "range": 20.0,
+    "duration": 4100,
+    "range": 20,
     "objectIds": [
       "DRAYNOR_MANOR_PORTAL_37607",
       "DRAYNOR_MANOR_PORTAL_37595",
@@ -23033,13 +23033,13 @@
     "radius": 400,
     "strength": 12.5,
     "color": [
-      0.075926125,
-      1.0,
-      0.5989418
+      79,
+      255,
+      202
     ],
     "type": "PULSE",
-    "duration": 4100.0,
-    "range": 20.0,
+    "duration": 4100,
+    "range": 20,
     "objectIds": [
       "BATTLEFRONT_PORTAL",
       "BATTLEFRONT_PORTAL_37608",
@@ -23053,13 +23053,13 @@
     "radius": 400,
     "strength": 12.5,
     "color": [
-      1.0,
-      0.45907992,
-      0.015175238
+      255,
+      179,
+      38
     ],
     "type": "PULSE",
-    "duration": 4100.0,
-    "range": 20.0,
+    "duration": 4100,
+    "range": 20,
     "objectIds": [
       "VARROCK_PORTAL_33104",
       "GRAND_EXCHANGE_PORTAL_33105",
@@ -23078,13 +23078,13 @@
     "radius": 400,
     "strength": 12.5,
     "color": [
-      1.0,
-      0.2801244,
-      0.015175238
+      255,
+      143,
+      38
     ],
     "type": "PULSE",
-    "duration": 4100.0,
-    "range": 20.0,
+    "duration": 4100,
+    "range": 20,
     "objectIds": [
       "MIND_ALTAR_PORTAL",
       "MIND_ALTAR_PORTAL_37609",
@@ -23098,13 +23098,13 @@
     "radius": 400,
     "strength": 12.5,
     "color": [
-      0.0,
-      0.20109573,
-      1.0
+      0,
+      123,
+      255
     ],
     "type": "PULSE",
-    "duration": 4100.0,
-    "range": 20.0,
+    "duration": 4100,
+    "range": 20,
     "objectIds": [
       "LUMBRIDGE_PORTAL",
       "LUMBRIDGE_PORTAL_13623",
@@ -23118,13 +23118,13 @@
     "radius": 400,
     "strength": 12.5,
     "color": [
-      0.43134022,
-      0.0,
-      1.0
+      174,
+      0,
+      255
     ],
     "type": "PULSE",
-    "duration": 4100.0,
-    "range": 20.0,
+    "duration": 4100,
+    "range": 20,
     "objectIds": [
       "FALADOR_PORTAL",
       "FALADOR_PORTAL_13624",
@@ -23138,13 +23138,13 @@
     "radius": 400,
     "strength": 12.5,
     "color": [
-      1.0,
-      0.5054325,
-      0.38891026
+      255,
+      187,
+      166
     ],
     "type": "PULSE",
-    "duration": 4100.0,
-    "range": 20.0,
+    "duration": 4100,
+    "range": 20,
     "objectIds": [
       "SALVE_GRAVEYARD_PORTAL",
       "SALVE_GRAVEYARD_PORTAL_37610",
@@ -23158,13 +23158,13 @@
     "radius": 400,
     "strength": 12.5,
     "color": [
-      1.0,
-      1.0,
-      1.0
+      255,
+      255,
+      255
     ],
     "type": "PULSE",
-    "duration": 4100.0,
-    "range": 20.0,
+    "duration": 4100,
+    "range": 20,
     "objectIds": [
       13632,
       "CAMELOT_PORTAL_33106",
@@ -23183,13 +23183,13 @@
     "radius": 400,
     "strength": 12.5,
     "color": [
-      1.0,
-      0.032875914,
-      0.7592996
+      255,
+      54,
+      225
     ],
     "type": "PULSE",
-    "duration": 4100.0,
-    "range": 20.0,
+    "duration": 4100,
+    "range": 20,
     "objectIds": [
       "FENKENSTRAINS_CASTLE_PORTAL",
       "FENKENSTRAINS_CASTLE_PORTAL_37611",
@@ -23203,13 +23203,13 @@
     "radius": 400,
     "strength": 12.5,
     "color": [
-      1.0,
-      0.0,
-      0.0
+      255,
+      0,
+      0
     ],
     "type": "PULSE",
-    "duration": 4100.0,
-    "range": 20.0,
+    "duration": 4100,
+    "range": 20,
     "objectIds": [
       "ARDOUGNE_PORTAL_13633",
       "ARDOUGNE_PORTAL",
@@ -23223,13 +23223,13 @@
     "radius": 400,
     "strength": 12.5,
     "color": [
-      0.0,
-      1.0,
-      0.0
+      0,
+      255,
+      0
     ],
     "type": "PULSE",
-    "duration": 4100.0,
-    "range": 20.0,
+    "duration": 4100,
+    "range": 20,
     "objectIds": [
       13634,
       "YANILLE_WATCHTOWER_PORTAL_33108",
@@ -23247,13 +23247,13 @@
     "radius": 400,
     "strength": 12.5,
     "color": [
-      0.034230206,
-      0.64555526,
-      0.02775528
+      55,
+      209,
+      50
     ],
     "type": "PULSE",
-    "duration": 4100.0,
-    "range": 20.0,
+    "duration": 4100,
+    "range": 20,
     "objectIds": [
       "SENNTISTEN_PORTAL_29348",
       "SENNTISTEN_PORTAL",
@@ -23267,13 +23267,13 @@
     "radius": 400,
     "strength": 12.5,
     "color": [
-      1.0,
-      0.0,
-      0.0
+      255,
+      0,
+      0
     ],
     "type": "PULSE",
-    "duration": 4100.0,
-    "range": 20.0,
+    "duration": 4100,
+    "range": 20,
     "objectIds": [
       "WEST_ARDOUGNE_PORTAL_37600",
       "WEST_ARDOUGNE_PORTAL",
@@ -23287,13 +23287,13 @@
     "radius": 400,
     "strength": 12.5,
     "color": [
-      1.0,
-      1.0,
-      0.0
+      255,
+      255,
+      0
     ],
     "type": "PULSE",
-    "duration": 4100.0,
-    "range": 20.0,
+    "duration": 4100,
+    "range": 20,
     "objectIds": [
       "MARIM_PORTAL",
       "MARIM_PORTAL_29360",
@@ -23307,13 +23307,13 @@
     "radius": 400,
     "strength": 12.5,
     "color": [
-      0.32503697,
-      0.9743002,
-      1.0
+      153,
+      252,
+      255
     ],
     "type": "PULSE",
-    "duration": 4100.0,
-    "range": 20.0,
+    "duration": 4100,
+    "range": 20,
     "objectIds": [
       "HARMONY_ISLAND_PORTAL_37601",
       "HARMONY_ISLAND_PORTAL",
@@ -23327,13 +23327,13 @@
     "radius": 400,
     "strength": 12.5,
     "color": [
-      1.0,
-      1.0,
-      1.0
+      255,
+      255,
+      255
     ],
     "type": "PULSE",
-    "duration": 4100.0,
-    "range": 20.0,
+    "duration": 4100,
+    "range": 20,
     "objectIds": [
       "KHARYRLL_PORTAL_29346",
       "KHARYRLL_PORTAL",
@@ -23347,13 +23347,13 @@
     "radius": 400,
     "strength": 12.5,
     "color": [
-      0.7154654,
-      0.32503697,
-      1.0
+      219,
+      153,
+      255
     ],
     "type": "PULSE",
-    "duration": 4100.0,
-    "range": 20.0,
+    "duration": 4100,
+    "range": 20,
     "objectIds": [
       "LUNAR_ISLE_PORTAL_29347",
       "LUNAR_ISLE_PORTAL",
@@ -23367,13 +23367,13 @@
     "radius": 400,
     "strength": 12.5,
     "color": [
-      0.0563741,
-      0.6120656,
-      0.17677432
+      69,
+      204,
+      116
     ],
     "type": "PULSE",
-    "duration": 4100.0,
-    "range": 20.0,
+    "duration": 4100,
+    "range": 20,
     "objectIds": [
       "KOUREND_PORTAL",
       "KOUREND_PORTAL_29361",
@@ -23387,13 +23387,13 @@
     "radius": 400,
     "strength": 12.5,
     "color": [
-      0.93227684,
-      0.8591736,
-      0.039947167
+      247,
+      238,
+      59
     ],
     "type": "PULSE",
-    "duration": 4100.0,
-    "range": 20.0,
+    "duration": 4100,
+    "range": 20,
     "objectIds": [
       "CEMETERY_PORTAL_37602",
       "CEMETERY_PORTAL",
@@ -23407,13 +23407,13 @@
     "radius": 400,
     "strength": 12.5,
     "color": [
-      0.19751643,
-      1.0,
-      0.6730491
+      122,
+      255,
+      213
     ],
     "type": "PULSE",
-    "duration": 4100.0,
-    "range": 20.0,
+    "duration": 4100,
+    "range": 20,
     "objectIds": [
       "WATERBIRTH_ISLAND_PORTAL_29350",
       "WATERBIRTH_ISLAND_PORTAL",
@@ -23427,13 +23427,13 @@
     "radius": 400,
     "strength": 12.5,
     "color": [
-      0.5989418,
-      0.19751643,
-      1.0
+      202,
+      122,
+      255
     ],
     "type": "PULSE",
-    "duration": 4100.0,
-    "range": 20.0,
+    "duration": 4100,
+    "range": 20,
     "objectIds": [
       "BARROWS_PORTAL_37603",
       "BARROWS_PORTAL",
@@ -23447,13 +23447,13 @@
     "radius": 400,
     "strength": 12.5,
     "color": [
-      0.7667436,
-      0.19751643,
-      1.0
+      226,
+      122,
+      255
     ],
     "type": "PULSE",
-    "duration": 4100.0,
-    "range": 20.0,
+    "duration": 4100,
+    "range": 20,
     "objectIds": [
       "CARRALLANGAR_PORTAL_33440",
       "CARRALLANGAR_PORTAL",
@@ -23467,13 +23467,13 @@
     "radius": 400,
     "strength": 12.5,
     "color": [
-      0.0,
-      0.8277258,
-      1.0
+      0,
+      234,
+      255
     ],
     "type": "PULSE",
-    "duration": 4100.0,
-    "range": 20.0,
+    "duration": 4100,
+    "range": 20,
     "objectIds": [
       "FISHING_GUILD_PORTAL_29351",
       "FISHING_GUILD_PORTAL",
@@ -23487,13 +23487,13 @@
     "radius": 400,
     "strength": 12.5,
     "color": [
-      1.0,
-      0.79691654,
-      0.0986892
+      255,
+      230,
+      89
     ],
     "type": "PULSE",
-    "duration": 4100.0,
-    "range": 20.0,
+    "duration": 4100,
+    "range": 20,
     "objectIds": [
       "CATHERBY_PORTAL",
       "CATHERBY_PORTAL_33435",
@@ -23507,13 +23507,13 @@
     "radius": 400,
     "strength": 12.5,
     "color": [
-      0.31118053,
-      0.31118053,
-      0.31118053
+      150,
+      150,
+      150
     ],
     "type": "PULSE",
-    "duration": 4100.0,
-    "range": 20.0,
+    "duration": 4100,
+    "range": 20,
     "objectIds": [
       "ANNAKARL_PORTAL_29349",
       "ANNAKARL_PORTAL",
@@ -23527,13 +23527,13 @@
     "radius": 400,
     "strength": 12.5,
     "color": [
-      1.0,
-      0.8355278,
-      0.035614368
+      255,
+      235,
+      56
     ],
     "type": "PULSE",
-    "duration": 4100.0,
-    "range": 20.0,
+    "duration": 4100,
+    "range": 20,
     "objectIds": [
       "APE_ATOLL_DUNGEON_PORTAL_37616",
       "APE_ATOLL_DUNGEON_PORTAL_37604",
@@ -23547,13 +23547,13 @@
     "radius": 400,
     "strength": 12.5,
     "color": [
-      0.9743002,
-      0.0,
-      0.8045591
+      252,
+      0,
+      231
     ],
     "type": "PULSE",
-    "duration": 4100.0,
-    "range": 20.0,
+    "duration": 4100,
+    "range": 20,
     "objectIds": [
       "GHORROCK_PORTAL",
       "GHORROCK_PORTAL_33436",
@@ -23567,13 +23567,13 @@
     "radius": 400,
     "strength": 12.5,
     "color": [
-      1.0,
-      0.20471011,
-      0.07176145
+      255,
+      124,
+      77
     ],
     "type": "PULSE",
-    "duration": 4100.0,
-    "range": 20.0,
+    "duration": 4100,
+    "range": 20,
     "objectIds": [
       "TROLL_STRONGHOLD_PORTAL",
       "TROLL_STRONGHOLD_PORTAL_33180",
@@ -23587,13 +23587,13 @@
     "radius": 400,
     "strength": 12.5,
     "color": [
-      0.0,
-      1.0,
-      1.0
+      0,
+      255,
+      255
     ],
     "type": "PULSE",
-    "duration": 4100.0,
-    "range": 20.0,
+    "duration": 4100,
+    "range": 20,
     "objectIds": [
       "WEISS_PORTAL_37605",
       "WEISS_PORTAL_37593",
@@ -23605,15 +23605,15 @@
     "height": 70,
     "alignment": "CENTER",
     "radius": 250,
-    "strength": 15.0,
+    "strength": 15,
     "color": [
-      1.0,
-      1.0,
-      1.0
+      255,
+      255,
+      255
     ],
     "type": "STATIC",
-    "duration": 0.0,
-    "range": 0.0,
+    "duration": 0,
+    "range": 0,
     "objectIds": [
       "CAVE_EXIT_3760"
     ]
@@ -23623,15 +23623,15 @@
     "height": 200,
     "alignment": "CENTER",
     "radius": 250,
-    "strength": 15.0,
+    "strength": 15,
     "color": [
-      1.0,
-      1.0,
-      1.0
+      255,
+      255,
+      255
     ],
     "type": "PULSE",
-    "duration": 1200.0,
-    "range": 30.0,
+    "duration": 1200,
+    "range": 30,
     "objectIds": [
       "WELL_4004",
       "WELL_4005"
@@ -23642,15 +23642,15 @@
     "height": 180,
     "alignment": "CENTER",
     "radius": 250,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      1.0,
-      1.0,
-      1.0
+      255,
+      255,
+      255
     ],
     "type": "PULSE",
-    "duration": 1000.0,
-    "range": 10.0,
+    "duration": 1000,
+    "range": 10,
     "objectIds": [
       "ELVEN_LAMP_35867",
       "ELVEN_LAMP_36492",
@@ -23667,13 +23667,13 @@
     "radius": 450,
     "strength": 12.5,
     "color": [
-      0.0,
-      0.585973,
-      0.7592996
+      0,
+      200,
+      225
     ],
     "type": "PULSE",
-    "duration": 1200.0,
-    "range": 10.0,
+    "duration": 1200,
+    "range": 10,
     "objectIds": [
       "PORTAL_35075"
     ]
@@ -23685,13 +23685,13 @@
     "radius": 200,
     "strength": 12.5,
     "color": [
-      0.0,
-      0.585973,
-      0.7592996
+      0,
+      200,
+      225
     ],
     "type": "PULSE",
-    "duration": 3200.0,
-    "range": 5.0,
+    "duration": 3200,
+    "range": 5,
     "objectIds": [
       34998
     ]
@@ -23703,13 +23703,13 @@
     "radius": 200,
     "strength": 12.5,
     "color": [
-      0.0,
-      0.585973,
-      0.7592996
+      0,
+      200,
+      225
     ],
     "type": "PULSE",
-    "duration": 3200.0,
-    "range": 5.0,
+    "duration": 3200,
+    "range": 5,
     "objectIds": [
       35059,
       35061,
@@ -23723,13 +23723,13 @@
     "radius": 200,
     "strength": 12.5,
     "color": [
-      0.0,
-      0.585973,
-      0.7592996
+      0,
+      200,
+      225
     ],
     "type": "STATIC",
-    "duration": 0.0,
-    "range": 0.0,
+    "duration": 0,
+    "range": 0,
     "objectIds": [
       35000
     ]
@@ -23741,13 +23741,13 @@
     "radius": 200,
     "strength": 12.5,
     "color": [
-      0.0,
-      0.585973,
-      0.7592996
+      0,
+      200,
+      225
     ],
     "type": "STATIC",
-    "duration": 0.0,
-    "range": 0.0,
+    "duration": 0,
+    "range": 0,
     "objectIds": [
       35065,
       35066,
@@ -23761,13 +23761,13 @@
     "radius": 300,
     "strength": 12.5,
     "color": [
-      0.0,
-      0.585973,
-      0.7592996
+      0,
+      200,
+      225
     ],
     "type": "PULSE",
-    "duration": 3200.0,
-    "range": 5.0,
+    "duration": 3200,
+    "range": 5,
     "objectIds": [
       "SEAL_OF_AMLODD_35456",
       "SEAL_OF_HEFIN",
@@ -23803,13 +23803,13 @@
     "radius": 500,
     "strength": 12.5,
     "color": [
-      0.0,
-      0.585973,
-      0.7592996
+      0,
+      200,
+      225
     ],
     "type": "PULSE",
-    "duration": 3200.0,
-    "range": 10.0,
+    "duration": 3200,
+    "range": 10,
     "objectIds": [
       37319
     ]
@@ -23821,13 +23821,13 @@
     "radius": 400,
     "strength": 12.5,
     "color": [
-      0.0,
-      1.0,
-      1.0
+      0,
+      255,
+      255
     ],
     "type": "FLICKER",
-    "duration": 0.0,
-    "range": 20.0,
+    "duration": 0,
+    "range": 20,
     "objectIds": [
       "TELEPORT_PLATFORM_35984",
       "TELEPORT_PLATFORM_35985",
@@ -23847,13 +23847,13 @@
     "radius": 700,
     "strength": 17.5,
     "color": [
-      0.0,
-      0.21576439,
-      1.0
+      0,
+      127,
+      255
     ],
     "type": "PULSE",
-    "duration": 5000.0,
-    "range": 20.0,
+    "duration": 5000,
+    "range": 20,
     "objectIds": [
       "GAUNTLET_PORTAL"
     ]
@@ -23865,13 +23865,13 @@
     "radius": 400,
     "strength": 12.5,
     "color": [
-      0.0,
-      1.0,
-      1.0
+      0,
+      255,
+      255
     ],
     "type": "PULSE",
-    "duration": 900.0,
-    "range": 20.0,
+    "duration": 900,
+    "range": 20,
     "objectIds": [
       37340
     ]
@@ -23883,13 +23883,13 @@
     "radius": 400,
     "strength": 12.5,
     "color": [
-      0.0,
-      1.0,
-      1.0
+      0,
+      255,
+      255
     ],
     "type": "STATIC",
-    "duration": 0.0,
-    "range": 0.0,
+    "duration": 0,
+    "range": 0,
     "objectIds": [
       37341
     ]
@@ -23901,13 +23901,13 @@
     "radius": 400,
     "strength": 12.5,
     "color": [
-      0.0,
-      1.0,
-      1.0
+      0,
+      255,
+      255
     ],
     "type": "STATIC",
-    "duration": 0.0,
-    "range": 0.0,
+    "duration": 0,
+    "range": 0,
     "objectIds": [
       "TOOL_STORAGE_36074"
     ]
@@ -23919,13 +23919,13 @@
     "radius": 400,
     "strength": 12.5,
     "color": [
-      0.0,
-      1.0,
-      1.0
+      0,
+      255,
+      255
     ],
     "type": "FLICKER",
-    "duration": 0.0,
-    "range": 20.0,
+    "duration": 0,
+    "range": 20,
     "objectIds": [
       "RANGE_36077"
     ]
@@ -23937,13 +23937,13 @@
     "radius": 400,
     "strength": 12.5,
     "color": [
-      0.0,
-      1.0,
-      1.0
+      0,
+      255,
+      255
     ],
     "type": "PULSE",
-    "duration": 3100.0,
-    "range": 20.0,
+    "duration": 3100,
+    "range": 20,
     "objectIds": [
       "SINGING_BOWL_36063"
     ]
@@ -23953,15 +23953,15 @@
     "height": 210,
     "alignment": "BACKRIGHT",
     "radius": 200,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      0.0,
-      1.0,
-      1.0
+      0,
+      255,
+      255
     ],
     "type": "STATIC",
-    "duration": 0.0,
-    "range": 0.0,
+    "duration": 0,
+    "range": 0,
     "objectIds": [
       36103
     ]
@@ -23971,15 +23971,15 @@
     "height": 210,
     "alignment": "BACKLEFT",
     "radius": 200,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      0.0,
-      1.0,
-      1.0
+      0,
+      255,
+      255
     ],
     "type": "STATIC",
-    "duration": 0.0,
-    "range": 0.0,
+    "duration": 0,
+    "range": 0,
     "objectIds": [
       36104
     ]
@@ -23989,15 +23989,15 @@
     "height": 210,
     "alignment": "CENTER",
     "radius": 200,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      0.0,
-      1.0,
-      1.0
+      0,
+      255,
+      255
     ],
     "type": "STATIC",
-    "duration": 0.0,
-    "range": 0.0,
+    "duration": 0,
+    "range": 0,
     "objectIds": [
       "PHREN_ROOTS_36066"
     ]
@@ -24007,15 +24007,15 @@
     "height": 40,
     "alignment": "CENTER",
     "radius": 200,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      0.0,
-      1.0,
-      1.0
+      0,
+      255,
+      255
     ],
     "type": "PULSE",
-    "duration": 2400.0,
-    "range": 20.0,
+    "duration": 2400,
+    "range": 20,
     "objectIds": [
       "CRYSTAL_DEPOSIT"
     ]
@@ -24027,13 +24027,13 @@
     "radius": 400,
     "strength": 12.5,
     "color": [
-      1.0,
-      0.0,
-      0.0
+      255,
+      0,
+      0
     ],
     "type": "FLICKER",
-    "duration": 0.0,
-    "range": 20.0,
+    "duration": 0,
+    "range": 20,
     "objectIds": [
       "TELEPORT_PLATFORM"
     ]
@@ -24045,13 +24045,13 @@
     "radius": 400,
     "strength": 12.5,
     "color": [
-      1.0,
-      0.0,
-      0.0
+      255,
+      0,
+      0
     ],
     "type": "STATIC",
-    "duration": 0.0,
-    "range": 0.0,
+    "duration": 0,
+    "range": 0,
     "objectIds": [
       "TOOL_STORAGE"
     ]
@@ -24063,13 +24063,13 @@
     "radius": 400,
     "strength": 12.5,
     "color": [
-      1.0,
-      0.0,
-      0.0
+      255,
+      0,
+      0
     ],
     "type": "FLICKER",
-    "duration": 0.0,
-    "range": 20.0,
+    "duration": 0,
+    "range": 20,
     "objectIds": [
       "RANGE_35980"
     ]
@@ -24081,13 +24081,13 @@
     "radius": 400,
     "strength": 12.5,
     "color": [
-      1.0,
-      0.0,
-      0.0
+      255,
+      0,
+      0
     ],
     "type": "PULSE",
-    "duration": 3100.0,
-    "range": 20.0,
+    "duration": 3100,
+    "range": 20,
     "objectIds": [
       "SINGING_BOWL_35966"
     ]
@@ -24097,15 +24097,15 @@
     "height": 210,
     "alignment": "BACKRIGHT",
     "radius": 200,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      1.0,
-      0.0,
-      0.0
+      255,
+      0,
+      0
     ],
     "type": "STATIC",
-    "duration": 0.0,
-    "range": 0.0,
+    "duration": 0,
+    "range": 0,
     "objectIds": [
       36000
     ]
@@ -24115,15 +24115,15 @@
     "height": 210,
     "alignment": "BACKLEFT",
     "radius": 200,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      1.0,
-      0.0,
-      0.0
+      255,
+      0,
+      0
     ],
     "type": "STATIC",
-    "duration": 0.0,
-    "range": 0.0,
+    "duration": 0,
+    "range": 0,
     "objectIds": [
       36001
     ]
@@ -24133,15 +24133,15 @@
     "height": 210,
     "alignment": "CENTER",
     "radius": 200,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      1.0,
-      0.0,
-      0.0
+      255,
+      0,
+      0
     ],
     "type": "STATIC",
-    "duration": 0.0,
-    "range": 0.0,
+    "duration": 0,
+    "range": 0,
     "objectIds": [
       "PHREN_ROOTS"
     ]
@@ -24151,15 +24151,15 @@
     "height": 40,
     "alignment": "CENTER",
     "radius": 200,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      1.0,
-      0.0,
-      0.0
+      255,
+      0,
+      0
     ],
     "type": "PULSE",
-    "duration": 2400.0,
-    "range": 20.0,
+    "duration": 2400,
+    "range": 20,
     "objectIds": [
       "CORRUPT_DEPOSIT"
     ]
@@ -24169,15 +24169,15 @@
     "height": 270,
     "alignment": "CENTER",
     "radius": 700,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      1.0,
-      0.0,
-      0.0
+      255,
+      0,
+      0
     ],
     "type": "PULSE",
-    "duration": 4300.0,
-    "range": 20.0,
+    "duration": 4300,
+    "range": 20,
     "objectIds": [
       "ROCK_FORMATION_GLOWING"
     ]
@@ -24189,13 +24189,13 @@
     "radius": 700,
     "strength": 2.5,
     "color": [
-      1.0,
-      0.0,
-      0.0
+      255,
+      0,
+      0
     ],
     "type": "PULSE",
-    "duration": 4300.0,
-    "range": 20.0,
+    "duration": 4300,
+    "range": 20,
     "objectIds": [
       "ROCK_FORMATION"
     ]
@@ -24205,15 +24205,15 @@
     "height": 300,
     "alignment": "FRONT",
     "radius": 1200,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      0.0,
-      1.0,
-      1.0
+      0,
+      255,
+      255
     ],
     "type": "STATIC",
-    "duration": 0.0,
-    "range": 0.0,
+    "duration": 0,
+    "range": 0,
     "objectIds": [
       "ALTAR_36196"
     ]
@@ -24225,13 +24225,13 @@
     "radius": 1800,
     "strength": 17.5,
     "color": [
-      1.0,
-      0.08919351,
-      0.0
+      255,
+      85,
+      0
     ],
     "type": "STATIC",
-    "duration": 0.0,
-    "range": 0.0,
+    "duration": 0,
+    "range": 0,
     "objectIds": [
       "FURNACE_36195"
     ]
@@ -24243,13 +24243,13 @@
     "radius": 500,
     "strength": 7.5,
     "color": [
-      1.0,
-      0.69408053,
-      0.09387587
+      255,
+      216,
+      87
     ],
     "type": "PULSE",
-    "duration": 1550.0,
-    "range": 20.0,
+    "duration": 1550,
+    "range": 20,
     "objectIds": [
       6550,
       "PORTAL_6551"
@@ -24262,13 +24262,13 @@
     "radius": 1400,
     "strength": 12.5,
     "color": [
-      1.0,
-      0.0,
-      0.0
+      255,
+      0,
+      0
     ],
     "type": "FLICKER",
-    "duration": 0.0,
-    "range": 20.0,
+    "duration": 0,
+    "range": 20,
     "objectIds": [
       6482
     ]
@@ -24280,13 +24280,13 @@
     "radius": 1400,
     "strength": 7.5,
     "color": [
-      1.0,
-      1.0,
-      1.0
+      255,
+      255,
+      255
     ],
     "type": "FLICKER",
-    "duration": 0.0,
-    "range": 20.0,
+    "duration": 0,
+    "range": 20,
     "objectIds": [
       6485
     ]
@@ -24298,13 +24298,13 @@
     "radius": 1400,
     "strength": 12.5,
     "color": [
-      0.065753885,
-      0.39929333,
-      1.0
+      74,
+      168,
+      255
     ],
     "type": "FLICKER",
-    "duration": 0.0,
-    "range": 20.0,
+    "duration": 0,
+    "range": 20,
     "objectIds": [
       6488
     ]
@@ -24316,13 +24316,13 @@
     "radius": 1400,
     "strength": 6.3,
     "color": [
-      1.0,
-      1.0,
-      1.0
+      255,
+      255,
+      255
     ],
     "type": "FLICKER",
-    "duration": 0.0,
-    "range": 20.0,
+    "duration": 0,
+    "range": 20,
     "objectIds": [
       6491
     ]
@@ -24332,15 +24332,15 @@
     "height": 100,
     "alignment": "FRONT",
     "radius": 400,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      1.0,
-      0.75189507,
-      0.38891026
+      255,
+      224,
+      166
     ],
     "type": "STATIC",
-    "duration": 0.0,
-    "range": 0.0,
+    "duration": 0,
+    "range": 0,
     "objectIds": [
       "TOMB_DOOR",
       "TOMB_DOOR_20932",
@@ -24355,13 +24355,13 @@
     "radius": 500,
     "strength": 12.5,
     "color": [
-      1.0,
-      1.0,
-      1.0
+      255,
+      255,
+      255
     ],
     "type": "PULSE",
-    "duration": 6200.0,
-    "range": 30.0,
+    "duration": 6200,
+    "range": 30,
     "objectIds": [
       14839,
       29495,
@@ -24374,15 +24374,15 @@
     "height": 200,
     "alignment": "CENTER",
     "radius": 1500,
-    "strength": 25.0,
+    "strength": 25,
     "color": [
-      0.0,
-      1.0,
-      1.0
+      0,
+      255,
+      255
     ],
     "type": "PULSE",
-    "duration": 6200.0,
-    "range": 30.0,
+    "duration": 6200,
+    "range": 30,
     "objectIds": [
       "ARCANE_CRYSTAL"
     ]
@@ -24392,15 +24392,15 @@
     "height": 180,
     "alignment": "CENTER",
     "radius": 1200,
-    "strength": 25.0,
+    "strength": 25,
     "color": [
-      0.0,
-      1.0,
-      1.0
+      0,
+      255,
+      255
     ],
     "type": "PULSE",
-    "duration": 4000.0,
-    "range": 30.0,
+    "duration": 4000,
+    "range": 30,
     "objectIds": [
       "ARCANE_CRYSTAL_27882"
     ]
@@ -24410,15 +24410,15 @@
     "height": 120,
     "alignment": "CENTER",
     "radius": 600,
-    "strength": 25.0,
+    "strength": 25,
     "color": [
-      0.0,
-      1.0,
-      1.0
+      0,
+      255,
+      255
     ],
     "type": "PULSE",
-    "duration": 2400.0,
-    "range": 30.0,
+    "duration": 2400,
+    "range": 30,
     "objectIds": [
       "ARCANE_CRYSTAL_27886"
     ]
@@ -24428,15 +24428,15 @@
     "height": 200,
     "alignment": "CENTER",
     "radius": 1500,
-    "strength": 25.0,
+    "strength": 25,
     "color": [
-      0.069727086,
-      0.0,
-      1.0
+      76,
+      0,
+      255
     ],
     "type": "PULSE",
-    "duration": 6100.0,
-    "range": 30.0,
+    "duration": 6100,
+    "range": 30,
     "objectIds": [
       "DARK_CRYSTAL"
     ]
@@ -24446,15 +24446,15 @@
     "height": 180,
     "alignment": "CENTER",
     "radius": 1200,
-    "strength": 25.0,
+    "strength": 25,
     "color": [
-      0.069727086,
-      0.0,
-      1.0
+      76,
+      0,
+      255
     ],
     "type": "PULSE",
-    "duration": 3900.0,
-    "range": 30.0,
+    "duration": 3900,
+    "range": 30,
     "objectIds": [
       "DARK_CRYSTAL_27883"
     ]
@@ -24464,15 +24464,15 @@
     "height": 120,
     "alignment": "CENTER",
     "radius": 600,
-    "strength": 25.0,
+    "strength": 25,
     "color": [
-      0.069727086,
-      0.0,
-      1.0
+      76,
+      0,
+      255
     ],
     "type": "PULSE",
-    "duration": 2300.0,
-    "range": 30.0,
+    "duration": 2300,
+    "range": 30,
     "objectIds": [
       "DARK_CRYSTAL_27887"
     ]
@@ -24482,15 +24482,15 @@
     "height": 200,
     "alignment": "CENTER",
     "radius": 1500,
-    "strength": 25.0,
+    "strength": 25,
     "color": [
-      1.0,
-      0.0,
-      0.0
+      255,
+      0,
+      0
     ],
     "type": "PULSE",
-    "duration": 6300.0,
-    "range": 30.0,
+    "duration": 6300,
+    "range": 30,
     "objectIds": [
       27881
     ]
@@ -24500,15 +24500,15 @@
     "height": 180,
     "alignment": "CENTER",
     "radius": 1200,
-    "strength": 25.0,
+    "strength": 25,
     "color": [
-      1.0,
-      0.0,
-      0.0
+      255,
+      0,
+      0
     ],
     "type": "PULSE",
-    "duration": 4100.0,
-    "range": 30.0,
+    "duration": 4100,
+    "range": 30,
     "objectIds": [
       "BLOOD_CRYSTAL_27884",
       27885
@@ -24519,15 +24519,15 @@
     "height": 120,
     "alignment": "CENTER",
     "radius": 600,
-    "strength": 25.0,
+    "strength": 25,
     "color": [
-      1.0,
-      0.0,
-      0.0
+      255,
+      0,
+      0
     ],
     "type": "PULSE",
-    "duration": 2500.0,
-    "range": 30.0,
+    "duration": 2500,
+    "range": 30,
     "objectIds": [
       "BLOOD_CRYSTAL_27888"
     ]
@@ -24537,15 +24537,15 @@
     "height": 200,
     "alignment": "CENTER",
     "radius": 500,
-    "strength": 25.0,
+    "strength": 25,
     "color": [
-      1.0,
-      0.0,
-      0.0
+      255,
+      0,
+      0
     ],
     "type": "STATIC",
-    "duration": 0.0,
-    "range": 0.0,
+    "duration": 0,
+    "range": 0,
     "objectIds": [
       "BLOOD_ALTAR"
     ]
@@ -24555,15 +24555,15 @@
     "height": 350,
     "alignment": "CENTER",
     "radius": 500,
-    "strength": 25.0,
+    "strength": 25,
     "color": [
-      0.069727086,
-      0.0,
-      1.0
+      76,
+      0,
+      255
     ],
     "type": "STATIC",
-    "duration": 0.0,
-    "range": 0.0,
+    "duration": 0,
+    "range": 0,
     "objectIds": [
       "DARK_ALTAR"
     ]
@@ -24573,15 +24573,15 @@
     "height": 350,
     "alignment": "CENTER",
     "radius": 500,
-    "strength": 25.0,
+    "strength": 25,
     "color": [
-      0.0,
-      1.0,
-      1.0
+      0,
+      255,
+      255
     ],
     "type": "STATIC",
-    "duration": 0.0,
-    "range": 0.0,
+    "duration": 0,
+    "range": 0,
     "objectIds": [
       "SOUL_ALTAR"
     ]
@@ -24591,15 +24591,15 @@
     "height": 120,
     "alignment": "CENTER",
     "radius": 600,
-    "strength": 15.0,
+    "strength": 15,
     "color": [
-      0.46474114,
-      0.8355278,
-      0.030256517
+      180,
+      235,
+      52
     ],
     "type": "PULSE",
-    "duration": 2400.0,
-    "range": 20.0,
+    "duration": 2400,
+    "range": 20,
     "objectIds": [
       "LARGE_CRYSTAL",
       "CRYSTAL_30018",
@@ -24612,15 +24612,15 @@
     "height": 480,
     "alignment": "CENTER",
     "radius": 600,
-    "strength": 15.0,
+    "strength": 15,
     "color": [
-      0.46474114,
-      0.8355278,
-      0.030256517
+      180,
+      235,
+      52
     ],
     "type": "PULSE",
-    "duration": 2400.0,
-    "range": 20.0,
+    "duration": 2400,
+    "range": 20,
     "objectIds": [
       29800
     ]
@@ -24630,15 +24630,15 @@
     "height": 120,
     "alignment": "CENTER",
     "radius": 600,
-    "strength": 15.0,
+    "strength": 15,
     "color": [
-      0.069727086,
-      0.0,
-      1.0
+      76,
+      0,
+      255
     ],
     "type": "PULSE",
-    "duration": 2400.0,
-    "range": 20.0,
+    "duration": 2400,
+    "range": 20,
     "objectIds": [
       29796
     ]
@@ -24648,15 +24648,15 @@
     "height": 180,
     "alignment": "CENTER",
     "radius": 900,
-    "strength": 15.0,
+    "strength": 15,
     "color": [
-      0.069727086,
-      0.0,
-      1.0
+      76,
+      0,
+      255
     ],
     "type": "PULSE",
-    "duration": 2400.0,
-    "range": 20.0,
+    "duration": 2400,
+    "range": 20,
     "objectIds": [
       "CRYSTAL_30016",
       29775
@@ -24667,15 +24667,15 @@
     "height": 480,
     "alignment": "CENTER",
     "radius": 600,
-    "strength": 15.0,
+    "strength": 15,
     "color": [
-      0.069727086,
-      0.0,
-      1.0
+      76,
+      0,
+      255
     ],
     "type": "PULSE",
-    "duration": 2400.0,
-    "range": 20.0,
+    "duration": 2400,
+    "range": 20,
     "objectIds": [
       29801
     ]
@@ -24685,15 +24685,15 @@
     "height": 120,
     "alignment": "CENTER",
     "radius": 600,
-    "strength": 15.0,
+    "strength": 15,
     "color": [
-      1.0,
-      0.36859095,
-      0.017936433
+      255,
+      162,
+      41
     ],
     "type": "PULSE",
-    "duration": 2400.0,
-    "range": 20.0,
+    "duration": 2400,
+    "range": 20,
     "objectIds": [
       "CRYSTAL_30017",
       29798
@@ -24704,15 +24704,15 @@
     "height": 480,
     "alignment": "CENTER",
     "radius": 600,
-    "strength": 15.0,
+    "strength": 15,
     "color": [
-      1.0,
-      0.36859095,
-      0.017936433
+      255,
+      162,
+      41
     ],
     "type": "PULSE",
-    "duration": 2400.0,
-    "range": 20.0,
+    "duration": 2400,
+    "range": 20,
     "objectIds": [
       29802
     ]
@@ -24722,15 +24722,15 @@
     "height": 120,
     "alignment": "CENTER",
     "radius": 600,
-    "strength": 15.0,
+    "strength": 15,
     "color": [
-      1.0,
-      0.0,
-      0.1869885
+      255,
+      0,
+      119
     ],
     "type": "PULSE",
-    "duration": 2400.0,
-    "range": 20.0,
+    "duration": 2400,
+    "range": 20,
     "objectIds": [
       "BLOOD_CRYSTAL_33147",
       "BLOOD_CRYSTAL_30014"
@@ -24741,15 +24741,15 @@
     "height": 120,
     "alignment": "CENTER",
     "radius": 900,
-    "strength": 15.0,
+    "strength": 15,
     "color": [
-      1.0,
-      0.36859095,
-      0.017936433
+      255,
+      162,
+      41
     ],
     "type": "PULSE",
-    "duration": 2400.0,
-    "range": 20.0,
+    "duration": 2400,
+    "range": 20,
     "objectIds": [
       "GIANT_ANVIL"
     ]
@@ -24761,13 +24761,13 @@
     "radius": 450,
     "strength": 7.5,
     "color": [
-      0.9743002,
-      0.3021255,
-      5.6921755E-5
+      252,
+      148,
+      3
     ],
     "type": "FLICKER",
-    "duration": 0.0,
-    "range": 20.0,
+    "duration": 0,
+    "range": 20,
     "objectIds": [
       "BRAZIER_29748"
     ]
@@ -24779,13 +24779,13 @@
     "radius": 800,
     "strength": 7.5,
     "color": [
-      0.069727086,
-      0.0,
-      1.0
+      76,
+      0,
+      255
     ],
     "type": "FLICKER",
-    "duration": 0.0,
-    "range": 20.0,
+    "duration": 0,
+    "range": 20,
     "objectIds": [
       "MAGICAL_FIRE"
     ]
@@ -24795,15 +24795,15 @@
     "height": 60,
     "alignment": "CENTER",
     "radius": 300,
-    "strength": 15.0,
+    "strength": 15,
     "color": [
-      1.0,
-      0.0,
-      1.0
+      255,
+      0,
+      255
     ],
     "type": "PULSE",
-    "duration": 2400.0,
-    "range": 20.0,
+    "duration": 2400,
+    "range": 20,
     "objectIds": [
       "MAGENTA_CRYSTAL",
       "MAGENTA_CRYSTAL_31958"
@@ -24814,15 +24814,15 @@
     "height": 60,
     "alignment": "CENTER",
     "radius": 300,
-    "strength": 15.0,
+    "strength": 15,
     "color": [
-      0.0,
-      1.0,
-      1.0
+      0,
+      255,
+      255
     ],
     "type": "PULSE",
-    "duration": 2400.0,
-    "range": 20.0,
+    "duration": 2400,
+    "range": 20,
     "objectIds": [
       "CYAN_CRYSTAL_31957",
       "CYAN_CRYSTAL"
@@ -24833,15 +24833,15 @@
     "height": 60,
     "alignment": "CENTER",
     "radius": 300,
-    "strength": 15.0,
+    "strength": 15,
     "color": [
-      1.0,
-      1.0,
-      0.0
+      255,
+      255,
+      0
     ],
     "type": "PULSE",
-    "duration": 2400.0,
-    "range": 20.0,
+    "duration": 2400,
+    "range": 20,
     "objectIds": [
       "YELLOW_CRYSTAL",
       "YELLOW_CRYSTAL_31959"
@@ -24852,15 +24852,15 @@
     "height": 60,
     "alignment": "CENTER",
     "radius": 300,
-    "strength": 5.0,
+    "strength": 5,
     "color": [
-      1.0,
-      1.0,
-      1.0
+      255,
+      255,
+      255
     ],
     "type": "PULSE",
-    "duration": 2400.0,
-    "range": 20.0,
+    "duration": 2400,
+    "range": 20,
     "objectIds": [
       "BLACK_CRYSTAL"
     ]
@@ -24872,13 +24872,13 @@
     "radius": 1000,
     "strength": 12.5,
     "color": [
-      0.52952325,
-      1.0,
-      0.0
+      191,
+      255,
+      0
     ],
     "type": "PULSE",
-    "duration": 1400.0,
-    "range": 20.0,
+    "duration": 1400,
+    "range": 20,
     "objectIds": [
       "MYSTICAL_BARRIER_34432",
       "MYSTICAL_BARRIER"
@@ -24891,13 +24891,13 @@
     "radius": 1000,
     "strength": 12.5,
     "color": [
-      1.0,
-      0.36859095,
-      0.0
+      255,
+      162,
+      0
     ],
     "type": "PULSE",
-    "duration": 1400.0,
-    "range": 20.0,
+    "duration": 1400,
+    "range": 20,
     "objectIds": [
       "MYSTICAL_BARRIER_ORANGE"
     ]
@@ -24909,13 +24909,13 @@
     "radius": 1000,
     "strength": 12.5,
     "color": [
-      1.0,
-      0.061907478,
-      0.0
+      255,
+      72,
+      0
     ],
     "type": "PULSE",
-    "duration": 1400.0,
-    "range": 20.0,
+    "duration": 1400,
+    "range": 20,
     "objectIds": [
       "MYSTICAL_BARRIER_RED"
     ]
@@ -24927,13 +24927,13 @@
     "radius": 450,
     "strength": 7.5,
     "color": [
-      1.0,
-      1.0,
-      1.0
+      255,
+      255,
+      255
     ],
     "type": "FLICKER",
-    "duration": 0.0,
-    "range": 20.0,
+    "duration": 0,
+    "range": 20,
     "objectIds": [
       "FIRE_10433"
     ]
@@ -24945,13 +24945,13 @@
     "radius": 1000,
     "strength": 12.5,
     "color": [
-      0.585973,
-      0.79691654,
-      1.0
+      200,
+      230,
+      255
     ],
     "type": "STATIC",
-    "duration": 0.0,
-    "range": 0.0,
+    "duration": 0,
+    "range": 0,
     "objectIds": [
       "LIGHT_34421"
     ]
@@ -24963,13 +24963,13 @@
     "radius": 600,
     "strength": 12.5,
     "color": [
-      0.52952325,
-      1.0,
-      0.0
+      191,
+      255,
+      0
     ],
     "type": "PULSE",
-    "duration": 1400.0,
-    "range": 20.0,
+    "duration": 1400,
+    "range": 20,
     "objectIds": [
       34642,
       34643,
@@ -24985,13 +24985,13 @@
     "radius": 500,
     "strength": 7.5,
     "color": [
-      1.0,
-      0.69408053,
-      0.09387587
+      255,
+      216,
+      87
     ],
     "type": "PULSE",
-    "duration": 1550.0,
-    "range": 20.0,
+    "duration": 1550,
+    "range": 20,
     "objectIds": [
       "PRIVATE_PORTAL",
       "PRIVATE_PORTAL_9369",
@@ -25005,13 +25005,13 @@
     "radius": 800,
     "strength": 12.5,
     "color": [
-      0.31118053,
-      0.72267246,
-      1.0
+      150,
+      220,
+      255
     ],
     "type": "STATIC",
-    "duration": 1550.0,
-    "range": 20.0,
+    "duration": 1550,
+    "range": 20,
     "objectIds": [
       "TUNNEL"
     ]
@@ -25023,13 +25023,13 @@
     "radius": 800,
     "strength": 7.5,
     "color": [
-      1.0,
-      1.0,
-      1.0
+      255,
+      255,
+      255
     ],
     "type": "STATIC",
-    "duration": 0.0,
-    "range": 0.0,
+    "duration": 0,
+    "range": 0,
     "objectIds": [
       "VINE_LADDER_31790"
     ]
@@ -25039,15 +25039,15 @@
     "height": 450,
     "alignment": "CENTER",
     "radius": 1200,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      0.9743002,
-      0.3021255,
-      5.6921755E-5
+      252,
+      148,
+      3
     ],
     "type": "FLICKER",
-    "duration": 0.0,
-    "range": 30.0,
+    "duration": 0,
+    "range": 30,
     "objectIds": [
       "BRAZIER_32119"
     ]
@@ -25059,13 +25059,13 @@
     "radius": 300,
     "strength": 22.5,
     "color": [
-      0.0986892,
-      0.288816,
-      1.0
+      89,
+      145,
+      255
     ],
     "type": "STATIC",
-    "duration": 0.0,
-    "range": 0.0,
+    "duration": 0,
+    "range": 0,
     "objectIds": [
       "BLUE_TEARS",
       "BLUE_TEARS_6665"
@@ -25076,15 +25076,15 @@
     "height": 100,
     "alignment": "CENTER",
     "radius": 300,
-    "strength": 15.0,
+    "strength": 15,
     "color": [
-      0.27157745,
-      1.0,
-      0.106156066
+      141,
+      255,
+      92
     ],
     "type": "STATIC",
-    "duration": 0.0,
-    "range": 0.0,
+    "duration": 0,
+    "range": 0,
     "objectIds": [
       "GREEN_TEARS",
       "GREEN_TEARS_6666"
@@ -25095,14 +25095,14 @@
     "height": 175,
     "alignment": "FRONT",
     "radius": 350,
-    "strength": 30.0,
+    "strength": 30,
     "color": [
-      0.0,
-      0.2673581,
-      1.0
+      0,
+      140,
+      255
     ],
     "type": "FLICKER",
-    "duration": 0.0,
+    "duration": 0,
     "range": 7.5,
     "objectIds": [
       41467
@@ -25115,13 +25115,13 @@
     "radius": 220,
     "strength": 12.5,
     "color": [
-      0.31118053,
-      0.0,
-      1.0
+      150,
+      0,
+      255
     ],
     "type": "PULSE",
-    "duration": 1700.0,
-    "range": 30.0,
+    "duration": 1700,
+    "range": 30,
     "objectIds": [
       41585
     ]
@@ -25133,13 +25133,13 @@
     "radius": 220,
     "strength": 17.5,
     "color": [
-      0.31118053,
-      0.0,
-      1.0
+      150,
+      0,
+      255
     ],
     "type": "PULSE",
-    "duration": 2200.0,
-    "range": 20.0,
+    "duration": 2200,
+    "range": 20,
     "objectIds": [
       "ROCKS_41547",
       "ROCKS_41548"
@@ -25152,13 +25152,13 @@
     "radius": 1400,
     "strength": 12.5,
     "color": [
-      0.9743002,
-      0.3021255,
-      5.6921755E-5
+      252,
+      148,
+      3
     ],
     "type": "FLICKER",
-    "duration": 0.0,
-    "range": 30.0,
+    "duration": 0,
+    "range": 30,
     "objectIds": [
       41411
     ]
@@ -25170,13 +25170,13 @@
     "radius": 200,
     "strength": 12.5,
     "color": [
-      0.9743002,
-      0.52344316,
-      0.0
+      252,
+      190,
+      0
     ],
     "type": "STATIC",
-    "duration": 0.0,
-    "range": 0.0,
+    "duration": 0,
+    "range": 0,
     "objectIds": [
       41520
     ]
@@ -25186,15 +25186,15 @@
     "height": 500,
     "alignment": "CENTER",
     "radius": 500,
-    "strength": 15.0,
+    "strength": 15,
     "color": [
-      1.0,
-      1.0,
-      1.0
+      255,
+      255,
+      255
     ],
     "type": "STATIC",
-    "duration": 0.0,
-    "range": 0.0,
+    "duration": 0,
+    "range": 0,
     "objectIds": [
       "WATER_41588"
     ]
@@ -25204,15 +25204,15 @@
     "height": 175,
     "alignment": "BACK",
     "radius": 300,
-    "strength": 25.0,
+    "strength": 25,
     "color": [
-      0.9743002,
-      0.3021255,
-      5.6921755E-5
+      252,
+      148,
+      3
     ],
     "type": "FLICKER",
-    "duration": 0.0,
-    "range": 20.0,
+    "duration": 0,
+    "range": 20,
     "objectIds": [
       41565
     ]
@@ -25224,13 +25224,13 @@
     "radius": 300,
     "strength": 8.8,
     "color": [
-      0.9743002,
-      0.3021255,
-      5.6921755E-5
+      252,
+      148,
+      3
     ],
     "type": "FLICKER",
-    "duration": 0.0,
-    "range": 30.0,
+    "duration": 0,
+    "range": 30,
     "objectIds": [
       "SHRINE_41236"
     ]
@@ -25242,13 +25242,13 @@
     "radius": 300,
     "strength": 8.8,
     "color": [
-      0.0,
-      1.0,
-      1.0
+      0,
+      255,
+      255
     ],
     "type": "FLICKER",
-    "duration": 0.0,
-    "range": 40.0,
+    "duration": 0,
+    "range": 40,
     "objectIds": [
       "ELECTRIFIED_HARPOONFISH_CANNON",
       "ELECTRIFIED_HARPOONFISH_CANNON_41243",
@@ -25263,13 +25263,13 @@
     "radius": 700,
     "strength": 12.5,
     "color": [
-      0.0,
-      0.0986892,
-      1.0
+      0,
+      89,
+      255
     ],
     "type": "STATIC",
-    "duration": 0.0,
-    "range": 0.0,
+    "duration": 0,
+    "range": 0,
     "objectIds": [
       "CLAN_HALL_PORTAL"
     ]
@@ -25281,13 +25281,13 @@
     "radius": 800,
     "strength": 7.5,
     "color": [
-      1.0,
-      1.0,
-      1.0
+      255,
+      255,
+      255
     ],
     "type": "FLICKER",
-    "duration": 0.0,
-    "range": 10.0,
+    "duration": 0,
+    "range": 10,
     "objectIds": [
       20868
     ]
@@ -25297,15 +25297,15 @@
     "height": 300,
     "alignment": "CENTER",
     "radius": 500,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      1.0,
-      0.6120656,
-      0.0
+      255,
+      204,
+      0
     ],
     "type": "PULSE",
-    "duration": 2100.0,
-    "range": 20.0,
+    "duration": 2100,
+    "range": 20,
     "objectIds": [
       "MAGICAL_OBELISK"
     ]
@@ -25315,15 +25315,15 @@
     "height": 200,
     "alignment": "CENTER",
     "radius": 500,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      0.0,
-      0.0,
-      1.0
+      0,
+      0,
+      255
     ],
     "type": "FLICKER",
-    "duration": 0.0,
-    "range": 20.0,
+    "duration": 0,
+    "range": 20,
     "objectIds": [
       39525,
       39526
@@ -25336,13 +25336,13 @@
     "radius": 300,
     "strength": 7.5,
     "color": [
-      1.0,
-      0.0,
-      0.0
+      255,
+      0,
+      0
     ],
     "type": "FLICKER",
-    "duration": 0.0,
-    "range": 20.0,
+    "duration": 0,
+    "range": 20,
     "objectIds": [
       "LAMP_39152"
     ]
@@ -25354,13 +25354,13 @@
     "radius": 800,
     "strength": 7.5,
     "color": [
-      1.0,
-      0.52952325,
-      0.0
+      255,
+      191,
+      0
     ],
     "type": "STATIC",
-    "duration": 0.0,
-    "range": 0.0,
+    "duration": 0,
+    "range": 0,
     "objectIds": [
       "MONUMENTAL_CHEST_32992",
       "MONUMENTAL_CHEST_32993",
@@ -25376,13 +25376,13 @@
     "radius": 300,
     "strength": 7.5,
     "color": [
-      0.9743002,
-      0.3021255,
-      5.6921755E-5
+      252,
+      148,
+      3
     ],
     "type": "FLICKER",
-    "duration": 0.0,
-    "range": 20.0,
+    "duration": 0,
+    "range": 20,
     "objectIds": [
       32998,
       32999
@@ -25395,13 +25395,13 @@
     "radius": 300,
     "strength": 7.5,
     "color": [
-      0.2673581,
-      0.0,
-      1.0
+      140,
+      0,
+      255
     ],
     "type": "PULSE",
-    "duration": 1800.0,
-    "range": 30.0,
+    "duration": 1800,
+    "range": 30,
     "objectIds": [
       "TELEPORT_CRYSTAL"
     ]
@@ -25413,13 +25413,13 @@
     "radius": 150,
     "strength": 7.5,
     "color": [
-      1.0,
-      0.0,
-      0.0
+      255,
+      0,
+      0
     ],
     "type": "PULSE",
-    "duration": 2200.0,
-    "range": 30.0,
+    "duration": 2200,
+    "range": 30,
     "objectIds": [
       "BARRIER_32755"
     ]
@@ -25429,15 +25429,15 @@
     "height": 400,
     "alignment": "CENTER",
     "radius": 1500,
-    "strength": 15.0,
+    "strength": 15,
     "color": [
-      1.0,
-      0.63877946,
-      0.0
+      255,
+      208,
+      0
     ],
     "type": "PULSE",
-    "duration": 1800.0,
-    "range": 10.0,
+    "duration": 1800,
+    "range": 10,
     "objectIds": [
       "CHAMBER"
     ]
@@ -25449,13 +25449,13 @@
     "radius": 1000,
     "strength": 16.3,
     "color": [
-      0.36859095,
-      0.0,
-      1.0
+      162,
+      0,
+      255
     ],
     "type": "STATIC",
-    "duration": 0.0,
-    "range": 0.0,
+    "duration": 0,
+    "range": 0,
     "objectIds": [
       32691
     ]
@@ -25465,15 +25465,15 @@
     "height": 450,
     "alignment": "FRONT",
     "radius": 600,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      0.36859095,
-      0.0,
-      1.0
+      162,
+      0,
+      255
     ],
     "type": "STATIC",
-    "duration": 0.0,
-    "range": 0.0,
+    "duration": 0,
+    "range": 0,
     "objectIds": [
       32697
     ]
@@ -25483,15 +25483,15 @@
     "height": 70,
     "alignment": "FRONT",
     "radius": 1000,
-    "strength": 5.0,
+    "strength": 5,
     "color": [
-      0.36859095,
-      0.0,
-      1.0
+      162,
+      0,
+      255
     ],
     "type": "STATIC",
-    "duration": 0.0,
-    "range": 0.0,
+    "duration": 0,
+    "range": 0,
     "objectIds": [
       32698
     ]
@@ -25501,15 +25501,15 @@
     "height": 400,
     "alignment": "FRONTRIGHT_CORNER",
     "radius": 1200,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      1.0,
-      1.0,
-      1.0
+      255,
+      255,
+      255
     ],
     "type": "STATIC",
-    "duration": 0.0,
-    "range": 0.0,
+    "duration": 0,
+    "range": 0,
     "objectIds": [
       33052
     ]
@@ -25519,15 +25519,15 @@
     "height": 820,
     "alignment": "FRONT",
     "radius": 300,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      1.0,
-      0.0,
-      0.0
+      255,
+      0,
+      0
     ],
     "type": "FLICKER",
-    "duration": 0.0,
-    "range": 20.0,
+    "duration": 0,
+    "range": 20,
     "objectIds": [
       32776
     ]
@@ -25539,13 +25539,13 @@
     "radius": 500,
     "strength": 7.5,
     "color": [
-      1.0,
-      0.69408053,
-      0.09387587
+      255,
+      216,
+      87
     ],
     "type": "PULSE",
-    "duration": 1550.0,
-    "range": 20.0,
+    "duration": 1550,
+    "range": 20,
     "objectIds": [
       "PORTAL_34748"
     ]
@@ -25555,15 +25555,15 @@
     "height": 250,
     "alignment": "CENTER",
     "radius": 300,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      1.0,
-      1.0,
-      1.0
+      255,
+      255,
+      255
     ],
     "type": "PULSE",
-    "duration": 500.0,
-    "range": 20.0,
+    "duration": 500,
+    "range": 20,
     "objectIds": [
       "MYSTERIOUS_GLOW_34790"
     ]
@@ -25575,13 +25575,13 @@
     "radius": 150,
     "strength": 7.5,
     "color": [
-      1.0,
-      0.0,
-      0.0
+      255,
+      0,
+      0
     ],
     "type": "PULSE",
-    "duration": 2200.0,
-    "range": 30.0,
+    "duration": 2200,
+    "range": 30,
     "objectIds": [
       "DOOR_20208",
       "DOOR_20209",
@@ -25601,15 +25601,15 @@
     "height": 125,
     "alignment": "CENTER",
     "radius": 150,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      1.0,
-      1.0,
-      1.0
+      255,
+      255,
+      255
     ],
     "type": "PULSE",
-    "duration": 500.0,
-    "range": 20.0,
+    "duration": 500,
+    "range": 20,
     "objectIds": [
       26274
     ]
@@ -25619,15 +25619,15 @@
     "height": 250,
     "alignment": "CENTER",
     "radius": 250,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      1.0,
-      1.0,
-      1.0
+      255,
+      255,
+      255
     ],
     "type": "PULSE",
-    "duration": 500.0,
-    "range": 20.0,
+    "duration": 500,
+    "range": 20,
     "objectIds": [
       "MYSTERIOUS_GLOW"
     ]
@@ -25637,15 +25637,15 @@
     "height": 250,
     "alignment": "CENTER",
     "radius": 250,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      0.0,
-      0.0,
-      1.0
+      0,
+      0,
+      255
     ],
     "type": "PULSE",
-    "duration": 500.0,
-    "range": 20.0,
+    "duration": 500,
+    "range": 20,
     "objectIds": [
       "MYSTERIOUS_GLOW_34791"
     ]
@@ -25657,13 +25657,13 @@
     "radius": 500,
     "strength": 7.5,
     "color": [
-      0.0,
-      0.0,
-      1.0
+      0,
+      0,
+      255
     ],
     "type": "PULSE",
-    "duration": 1550.0,
-    "range": 20.0,
+    "duration": 1550,
+    "range": 20,
     "objectIds": [
       "MAGIC_PORTAL",
       "MAGIC_PORTAL_2157",
@@ -25677,17 +25677,17 @@
     "radius": 500,
     "strength": 7.5,
     "color": [
-      0.9743002,
-      0.3021255,
-      5.6921755E-5
+      252,
+      148,
+      3
     ],
     "type": "FLICKER",
-    "duration": 0.0,
-    "range": 20.0,
+    "duration": 0,
+    "range": 20,
     "objectIds": [
-      "LAMP_22976",
       23040,
       23041,
+      "LAMP_22976",
       22978,
       22979,
       22980,
@@ -25745,13 +25745,13 @@
     "radius": 250,
     "strength": 12.5,
     "color": [
-      0.12752977,
-      0.40982577,
-      1.0
+      100,
+      170,
+      255
     ],
     "type": "FLICKER",
-    "duration": 0.0,
-    "range": 20.0,
+    "duration": 0,
+    "range": 20,
     "objectIds": [
       "ZAPPER_22736",
       "ZAPPER_22737",
@@ -25765,13 +25765,13 @@
     "radius": 300,
     "strength": 12.5,
     "color": [
-      0.02775528,
-      8.0465846E-4,
-      1.0
+      50,
+      10,
+      255
     ],
     "type": "FLICKER",
-    "duration": 0.0,
-    "range": 20.0,
+    "duration": 0,
+    "range": 20,
     "objectIds": [
       "MAGIC_BALL"
     ]
@@ -25781,15 +25781,15 @@
     "height": 150,
     "alignment": "CENTER",
     "radius": 500,
-    "strength": 15.0,
+    "strength": 15,
     "color": [
-      0.02775528,
-      8.0465846E-4,
-      1.0
+      50,
+      10,
+      255
     ],
     "type": "FLICKER",
-    "duration": 0.0,
-    "range": 20.0,
+    "duration": 0,
+    "range": 20,
     "objectIds": [
       "THINGYMAJIG"
     ]
@@ -25801,13 +25801,13 @@
     "radius": 700,
     "strength": 7.5,
     "color": [
-      0.9743002,
-      0.3021255,
-      5.6921755E-5
+      252,
+      148,
+      3
     ],
     "type": "FLICKER",
-    "duration": 0.0,
-    "range": 30.0,
+    "duration": 0,
+    "range": 30,
     "objectIds": [
       "FURNACE_22721"
     ]
@@ -25817,17 +25817,17 @@
     "height": 20,
     "alignment": "CENTER",
     "radius": 500,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      0.0,
-      1.0,
-      0.0
+      0,
+      255,
+      0
     ],
     "type": "FLICKER",
-    "duration": 0.0,
-    "range": 20.0,
+    "duration": 0,
+    "range": 20,
     "objectIds": [
-      43146
+      "FIRE_43146"
     ]
   },
   {
@@ -25837,15 +25837,15 @@
     "radius": 600,
     "strength": 12.5,
     "color": [
-      0.9743002,
-      0.3021255,
-      5.6921755E-5
+      252,
+      148,
+      3
     ],
     "type": "FLICKER",
-    "duration": 0.0,
-    "range": 20.0,
+    "duration": 0,
+    "range": 20,
     "objectIds": [
-      43089
+      "ALTAR_43089"
     ]
   },
   {
@@ -25853,15 +25853,15 @@
     "height": 300,
     "alignment": "CENTER",
     "radius": 1200,
-    "strength": 25.0,
+    "strength": 25,
     "color": [
-      0.9743002,
-      0.3021255,
-      5.6921755E-5
+      252,
+      148,
+      3
     ],
     "type": "FLICKER",
-    "duration": 0.0,
-    "range": 20.0,
+    "duration": 0,
+    "range": 20,
     "objectIds": [
       "MELTING_POT"
     ]
@@ -25873,13 +25873,13 @@
     "radius": 320,
     "strength": 17.5,
     "color": [
-      0.20109573,
-      0.6120656,
-      0.43134022
+      123,
+      204,
+      174
     ],
     "type": "STATIC",
-    "duration": 0.0,
-    "range": 30.0,
+    "duration": 0,
+    "range": 30,
     "objectIds": [
       "EMBALMING_TUBE"
     ]
@@ -25889,15 +25889,15 @@
     "height": 120,
     "alignment": "CENTER",
     "radius": 800,
-    "strength": 5.0,
+    "strength": 5,
     "color": [
-      0.9743002,
-      0.3021255,
-      5.6921755E-5
+      252,
+      148,
+      3
     ],
     "type": "FLICKER",
-    "duration": 0.0,
-    "range": 20.0,
+    "duration": 0,
+    "range": 20,
     "objectIds": [
       "RANGE_26181"
     ]
@@ -25909,13 +25909,13 @@
     "radius": 450,
     "strength": 7.5,
     "color": [
-      1.0,
-      0.46474114,
-      0.13609855
+      255,
+      180,
+      103
     ],
     "type": "STATIC",
-    "duration": 0.0,
-    "range": 20.0,
+    "duration": 0,
+    "range": 20,
     "objectIds": [
       205
     ]
@@ -25927,13 +25927,13 @@
     "radius": 650,
     "strength": 17.5,
     "color": [
-      0.9743002,
-      0.3021255,
-      5.6921755E-5
+      252,
+      148,
+      3
     ],
     "type": "FLICKER",
-    "duration": 0.0,
-    "range": 20.0,
+    "duration": 0,
+    "range": 20,
     "objectIds": [
       26570
     ]
@@ -25943,15 +25943,15 @@
     "height": 100,
     "alignment": "CENTER",
     "radius": 700,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      1.0,
-      0.028991185,
-      0.0
+      255,
+      51,
+      0
     ],
     "type": "PULSE",
-    "duration": 2200.0,
-    "range": 10.0,
+    "duration": 2200,
+    "range": 10,
     "objectIds": [
       42968
     ]
@@ -25961,15 +25961,15 @@
     "height": 100,
     "alignment": "CENTER",
     "radius": 700,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      0.48195225,
-      0.0,
-      1.0
+      183,
+      0,
+      255
     ],
     "type": "PULSE",
-    "duration": 2200.0,
-    "range": 10.0,
+    "duration": 2200,
+    "range": 10,
     "objectIds": [
       42967
     ]
@@ -25979,15 +25979,15 @@
     "height": 100,
     "alignment": "CENTER",
     "radius": 350,
-    "strength": 20.0,
+    "strength": 20,
     "color": [
-      0.0,
-      0.585973,
-      1.0
+      0,
+      200,
+      255
     ],
     "type": "FLICKER",
-    "duration": 0.0,
-    "range": 10.0,
+    "duration": 0,
+    "range": 10,
     "objectIds": [
       "ANCIENT_FORGE"
     ]
@@ -25999,13 +25999,13 @@
     "radius": 500,
     "strength": 7.5,
     "color": [
-      1.0,
-      0.69408053,
-      0.09387587
+      255,
+      216,
+      87
     ],
     "type": "PULSE",
-    "duration": 1550.0,
-    "range": 20.0,
+    "duration": 1550,
+    "range": 20,
     "objectIds": [
       "EXIT_PORTAL_20843"
     ]
@@ -26017,13 +26017,13 @@
     "radius": 300,
     "strength": 7.5,
     "color": [
-      1.0,
-      0.69408053,
-      0.09387587
+      255,
+      216,
+      87
     ],
     "type": "PULSE",
-    "duration": 2800.0,
-    "range": 30.0,
+    "duration": 2800,
+    "range": 30,
     "objectIds": [
       "STRANGE_SHRINE"
     ]
@@ -26033,13 +26033,13 @@
     "radius": 175,
     "strength": 2.5,
     "color": [
-      1.0,
-      1.0,
-      1.0
+      255,
+      255,
+      255
     ],
     "type": "STATIC",
-    "duration": 0.0,
-    "range": 0.0,
+    "duration": 0,
+    "range": 0,
     "fadeInDuration": 1000,
     "projectileIds": [
       91
@@ -26050,13 +26050,13 @@
     "radius": 175,
     "strength": 3.8,
     "color": [
-      0.0,
-      0.2673581,
-      1.0
+      0,
+      140,
+      255
     ],
     "type": "STATIC",
-    "duration": 0.0,
-    "range": 0.0,
+    "duration": 0,
+    "range": 0,
     "fadeInDuration": 1000,
     "projectileIds": [
       94
@@ -26067,13 +26067,13 @@
     "radius": 175,
     "strength": 3.1,
     "color": [
-      0.0,
-      1.0,
-      0.0
+      0,
+      255,
+      0
     ],
     "type": "STATIC",
-    "duration": 0.0,
-    "range": 0.0,
+    "duration": 0,
+    "range": 0,
     "fadeInDuration": 1000,
     "projectileIds": [
       97
@@ -26084,13 +26084,13 @@
     "radius": 175,
     "strength": 3.8,
     "color": [
-      1.0,
-      0.0,
-      0.0
+      255,
+      0,
+      0
     ],
     "type": "STATIC",
-    "duration": 0.0,
-    "range": 0.0,
+    "duration": 0,
+    "range": 0,
     "fadeInDuration": 1000,
     "projectileIds": [
       100
@@ -26101,13 +26101,13 @@
     "radius": 210,
     "strength": 3.8,
     "color": [
-      1.0,
-      1.0,
-      1.0
+      255,
+      255,
+      255
     ],
     "type": "STATIC",
-    "duration": 0.0,
-    "range": 0.0,
+    "duration": 0,
+    "range": 0,
     "fadeInDuration": 1000,
     "projectileIds": [
       118
@@ -26118,13 +26118,13 @@
     "radius": 210,
     "strength": 6.3,
     "color": [
-      0.0,
-      0.2673581,
-      1.0
+      0,
+      140,
+      255
     ],
     "type": "STATIC",
-    "duration": 0.0,
-    "range": 0.0,
+    "duration": 0,
+    "range": 0,
     "fadeInDuration": 1000,
     "projectileIds": [
       121
@@ -26135,13 +26135,13 @@
     "radius": 210,
     "strength": 5.6,
     "color": [
-      0.0,
-      1.0,
-      0.0
+      0,
+      255,
+      0
     ],
     "type": "STATIC",
-    "duration": 0.0,
-    "range": 0.0,
+    "duration": 0,
+    "range": 0,
     "fadeInDuration": 1000,
     "projectileIds": [
       124
@@ -26152,13 +26152,13 @@
     "radius": 210,
     "strength": 6.3,
     "color": [
-      1.0,
-      0.0,
-      0.0
+      255,
+      0,
+      0
     ],
     "type": "STATIC",
-    "duration": 0.0,
-    "range": 0.0,
+    "duration": 0,
+    "range": 0,
     "fadeInDuration": 1000,
     "projectileIds": [
       127
@@ -26169,13 +26169,13 @@
     "radius": 250,
     "strength": 5.6,
     "color": [
-      1.0,
-      1.0,
-      1.0
+      255,
+      255,
+      255
     ],
     "type": "STATIC",
-    "duration": 0.0,
-    "range": 0.0,
+    "duration": 0,
+    "range": 0,
     "fadeInDuration": 1000,
     "projectileIds": [
       133
@@ -26186,13 +26186,13 @@
     "radius": 250,
     "strength": 8.8,
     "color": [
-      0.0,
-      0.2673581,
-      1.0
+      0,
+      140,
+      255
     ],
     "type": "STATIC",
-    "duration": 0.0,
-    "range": 0.0,
+    "duration": 0,
+    "range": 0,
     "fadeInDuration": 1000,
     "projectileIds": [
       136
@@ -26203,13 +26203,13 @@
     "radius": 250,
     "strength": 6.9,
     "color": [
-      0.0,
-      1.0,
-      0.0
+      0,
+      255,
+      0
     ],
     "type": "STATIC",
-    "duration": 0.0,
-    "range": 0.0,
+    "duration": 0,
+    "range": 0,
     "fadeInDuration": 1000,
     "projectileIds": [
       139
@@ -26220,13 +26220,13 @@
     "radius": 250,
     "strength": 8.8,
     "color": [
-      1.0,
-      0.0,
-      0.0
+      255,
+      0,
+      0
     ],
     "type": "STATIC",
-    "duration": 0.0,
-    "range": 0.0,
+    "duration": 0,
+    "range": 0,
     "fadeInDuration": 1000,
     "projectileIds": [
       130
@@ -26237,13 +26237,13 @@
     "radius": 300,
     "strength": 7.5,
     "color": [
-      1.0,
-      1.0,
-      1.0
+      255,
+      255,
+      255
     ],
     "type": "STATIC",
-    "duration": 0.0,
-    "range": 0.0,
+    "duration": 0,
+    "range": 0,
     "fadeInDuration": 1000,
     "projectileIds": [
       159
@@ -26252,15 +26252,15 @@
   {
     "description": "WATER_WAVE",
     "radius": 300,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      0.0,
-      0.2673581,
-      1.0
+      0,
+      140,
+      255
     ],
     "type": "STATIC",
-    "duration": 0.0,
-    "range": 0.0,
+    "duration": 0,
+    "range": 0,
     "fadeInDuration": 1000,
     "projectileIds": [
       162
@@ -26271,13 +26271,13 @@
     "radius": 300,
     "strength": 8.8,
     "color": [
-      0.0,
-      1.0,
-      0.0
+      0,
+      255,
+      0
     ],
     "type": "STATIC",
-    "duration": 0.0,
-    "range": 0.0,
+    "duration": 0,
+    "range": 0,
     "fadeInDuration": 1000,
     "projectileIds": [
       165
@@ -26286,15 +26286,15 @@
   {
     "description": "FIRE_WAVE",
     "radius": 300,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      1.0,
-      0.0,
-      0.0
+      255,
+      0,
+      0
     ],
     "type": "STATIC",
-    "duration": 0.0,
-    "range": 0.0,
+    "duration": 0,
+    "range": 0,
     "fadeInDuration": 1000,
     "projectileIds": [
       156
@@ -26305,13 +26305,13 @@
     "radius": 400,
     "strength": 10.6,
     "color": [
-      1.0,
-      1.0,
-      1.0
+      255,
+      255,
+      255
     ],
     "type": "STATIC",
-    "duration": 0.0,
-    "range": 0.0,
+    "duration": 0,
+    "range": 0,
     "fadeInDuration": 1000,
     "projectileIds": [
       1456
@@ -26322,13 +26322,13 @@
     "radius": 400,
     "strength": 13.8,
     "color": [
-      0.0,
-      0.2673581,
-      1.0
+      0,
+      140,
+      255
     ],
     "type": "STATIC",
-    "duration": 0.0,
-    "range": 0.0,
+    "duration": 0,
+    "range": 0,
     "fadeInDuration": 1000,
     "projectileIds": [
       1459
@@ -26339,13 +26339,13 @@
     "radius": 400,
     "strength": 12.5,
     "color": [
-      0.0,
-      1.0,
-      0.0
+      0,
+      255,
+      0
     ],
     "type": "STATIC",
-    "duration": 0.0,
-    "range": 0.0,
+    "duration": 0,
+    "range": 0,
     "fadeInDuration": 1000,
     "projectileIds": [
       1462
@@ -26356,13 +26356,13 @@
     "radius": 400,
     "strength": 13.8,
     "color": [
-      1.0,
-      0.0,
-      0.0
+      255,
+      0,
+      0
     ],
     "type": "STATIC",
-    "duration": 0.0,
-    "range": 0.0,
+    "duration": 0,
+    "range": 0,
     "fadeInDuration": 1000,
     "projectileIds": [
       1465
@@ -26371,15 +26371,15 @@
   {
     "description": "CONFUSE",
     "radius": 200,
-    "strength": 5.0,
+    "strength": 5,
     "color": [
-      1.0,
-      0.0,
-      1.0
+      255,
+      0,
+      255
     ],
     "type": "PULSE",
-    "duration": 500.0,
-    "range": 20.0,
+    "duration": 500,
+    "range": 20,
     "fadeInDuration": 1000,
     "projectileIds": [
       103
@@ -26390,13 +26390,13 @@
     "radius": 200,
     "strength": 3.8,
     "color": [
-      1.0,
-      1.0,
-      1.0
+      255,
+      255,
+      255
     ],
     "type": "PULSE",
-    "duration": 500.0,
-    "range": 20.0,
+    "duration": 500,
+    "range": 20,
     "fadeInDuration": 1000,
     "projectileIds": [
       106
@@ -26405,15 +26405,15 @@
   {
     "description": "CURSE",
     "radius": 200,
-    "strength": 5.0,
+    "strength": 5,
     "color": [
-      1.0,
-      0.0,
-      1.0
+      255,
+      0,
+      255
     ],
     "type": "PULSE",
-    "duration": 500.0,
-    "range": 20.0,
+    "duration": 500,
+    "range": 20,
     "fadeInDuration": 1000,
     "projectileIds": [
       109
@@ -26424,13 +26424,13 @@
     "radius": 250,
     "strength": 6.3,
     "color": [
-      1.0,
-      0.0,
-      1.0
+      255,
+      0,
+      255
     ],
     "type": "PULSE",
-    "duration": 500.0,
-    "range": 20.0,
+    "duration": 500,
+    "range": 20,
     "fadeInDuration": 1000,
     "projectileIds": [
       168
@@ -26441,13 +26441,13 @@
     "radius": 250,
     "strength": 6.3,
     "color": [
-      1.0,
-      0.0,
-      1.0
+      255,
+      0,
+      255
     ],
     "type": "PULSE",
-    "duration": 500.0,
-    "range": 20.0,
+    "duration": 500,
+    "range": 20,
     "fadeInDuration": 1000,
     "projectileIds": [
       171
@@ -26456,15 +26456,15 @@
   {
     "description": "STUN",
     "radius": 250,
-    "strength": 5.0,
+    "strength": 5,
     "color": [
-      1.0,
-      1.0,
-      1.0
+      255,
+      255,
+      255
     ],
     "type": "PULSE",
-    "duration": 500.0,
-    "range": 20.0,
+    "duration": 500,
+    "range": 20,
     "fadeInDuration": 1000,
     "projectileIds": [
       174
@@ -26475,13 +26475,13 @@
     "radius": 200,
     "strength": 6.3,
     "color": [
-      0.0,
-      1.0,
-      0.0
+      0,
+      255,
+      0
     ],
     "type": "PULSE",
-    "duration": 500.0,
-    "range": 20.0,
+    "duration": 500,
+    "range": 20,
     "fadeInDuration": 1000,
     "projectileIds": [
       178
@@ -26490,15 +26490,15 @@
   {
     "description": "CRUMBLE_UNDEAD",
     "radius": 200,
-    "strength": 5.0,
+    "strength": 5,
     "color": [
-      1.0,
-      1.0,
-      1.0
+      255,
+      255,
+      255
     ],
     "type": "STATIC",
-    "duration": 0.0,
-    "range": 0.0,
+    "duration": 0,
+    "range": 0,
     "fadeInDuration": 1000,
     "projectileIds": [
       146
@@ -26509,13 +26509,13 @@
     "radius": 200,
     "strength": 7.5,
     "color": [
-      0.39929333,
-      1.0,
-      0.62534475
+      168,
+      255,
+      206
     ],
     "type": "STATIC",
-    "duration": 0.0,
-    "range": 0.0,
+    "duration": 0,
+    "range": 0,
     "fadeInDuration": 1000,
     "projectileIds": [
       328
@@ -26526,13 +26526,13 @@
     "radius": 200,
     "strength": 7.5,
     "color": [
-      1.0,
-      0.43681276,
-      0.086901255
+      255,
+      175,
+      84
     ],
     "type": "STATIC",
-    "duration": 0.0,
-    "range": 0.0,
+    "duration": 0,
+    "range": 0,
     "fadeInDuration": 1000,
     "projectileIds": [
       88
@@ -26541,15 +26541,15 @@
   {
     "description": "TELE_BLOCK",
     "radius": 200,
-    "strength": 5.0,
+    "strength": 5,
     "color": [
-      1.0,
-      1.0,
-      1.0
+      255,
+      255,
+      255
     ],
     "type": "PULSE",
-    "duration": 500.0,
-    "range": 20.0,
+    "duration": 500,
+    "range": 20,
     "fadeInDuration": 1000,
     "projectileIds": [
       344
@@ -26560,13 +26560,13 @@
     "radius": 400,
     "strength": 12.5,
     "color": [
-      0.0,
-      0.39408314,
-      0.6120656
+      0,
+      167,
+      204
     ],
     "type": "STATIC",
-    "duration": 0.0,
-    "range": 0.0,
+    "duration": 0,
+    "range": 0,
     "fadeInDuration": 1000,
     "projectileIds": [
       1040
@@ -26577,13 +26577,13 @@
     "radius": 400,
     "strength": 7.5,
     "color": [
-      0.0,
-      0.0,
-      1.0
+      0,
+      0,
+      255
     ],
     "type": "STATIC",
-    "duration": 0.0,
-    "range": 0.0,
+    "duration": 0,
+    "range": 0,
     "fadeInDuration": 1000,
     "projectileIds": [
       1252
@@ -26594,13 +26594,13 @@
     "radius": 250,
     "strength": 1.3,
     "color": [
-      1.0,
-      1.0,
-      1.0
+      255,
+      255,
+      255
     ],
     "type": "STATIC",
-    "duration": 0.0,
-    "range": 0.0,
+    "duration": 0,
+    "range": 0,
     "fadeInDuration": 1000,
     "projectileIds": [
       384
@@ -26611,13 +26611,13 @@
     "radius": 250,
     "strength": 2.5,
     "color": [
-      1.0,
-      1.0,
-      1.0
+      255,
+      255,
+      255
     ],
     "type": "STATIC",
-    "duration": 0.0,
-    "range": 0.0,
+    "duration": 0,
+    "range": 0,
     "fadeInDuration": 1000,
     "projectileIds": [
       378
@@ -26626,15 +26626,15 @@
   {
     "description": "ICE_RUSH",
     "radius": 250,
-    "strength": 5.0,
+    "strength": 5,
     "color": [
-      1.0,
-      1.0,
-      1.0
+      255,
+      255,
+      255
     ],
     "type": "STATIC",
-    "duration": 0.0,
-    "range": 0.0,
+    "duration": 0,
+    "range": 0,
     "fadeInDuration": 1000,
     "projectileIds": [
       360
@@ -26645,13 +26645,13 @@
     "radius": 250,
     "strength": 1.3,
     "color": [
-      1.0,
-      1.0,
-      1.0
+      255,
+      255,
+      255
     ],
     "type": "STATIC",
-    "duration": 0.0,
-    "range": 0.0,
+    "duration": 0,
+    "range": 0,
     "fadeInDuration": 1000,
     "projectileIds": [
       386
@@ -26662,13 +26662,13 @@
     "radius": 250,
     "strength": 2.5,
     "color": [
-      1.0,
-      1.0,
-      1.0
+      255,
+      255,
+      255
     ],
     "type": "STATIC",
-    "duration": 0.0,
-    "range": 0.0,
+    "duration": 0,
+    "range": 0,
     "fadeInDuration": 1000,
     "projectileIds": [
       380
@@ -26677,15 +26677,15 @@
   {
     "description": "BLOOD_BLITZ",
     "radius": 250,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      1.0,
-      0.0,
-      0.0
+      255,
+      0,
+      0
     ],
     "type": "STATIC",
-    "duration": 0.0,
-    "range": 0.0,
+    "duration": 0,
+    "range": 0,
     "fadeInDuration": 1000,
     "projectileIds": [
       374
@@ -26696,13 +26696,13 @@
     "radius": 250,
     "strength": 7.5,
     "color": [
-      0.030256517,
-      0.8355278,
-      0.16687226
+      52,
+      235,
+      113
     ],
     "type": "STATIC",
-    "duration": 0.0,
-    "range": 0.0,
+    "duration": 0,
+    "range": 0,
     "fadeInDuration": 300,
     "projectileIds": [
       249
@@ -26713,13 +26713,13 @@
     "radius": 250,
     "strength": 7.5,
     "color": [
-      1.0,
-      0.57954663,
-      0.13320851
+      255,
+      199,
+      102
     ],
     "type": "STATIC",
-    "duration": 0.0,
-    "range": 0.0,
+    "duration": 0,
+    "range": 0,
     "fadeInDuration": 300,
     "projectileIds": [
       1574
@@ -26730,13 +26730,13 @@
     "radius": 200,
     "strength": 6.3,
     "color": [
-      0.9743002,
-      0.19751643,
-      5.6921755E-5
+      252,
+      122,
+      3
     ],
     "type": "FLICKER",
-    "duration": 0.0,
-    "range": 30.0,
+    "duration": 0,
+    "range": 30,
     "fadeInDuration": 300,
     "projectileIds": [
       17
@@ -26747,13 +26747,13 @@
     "radius": 250,
     "strength": 7.5,
     "color": [
-      1.0,
-      1.0,
-      1.0
+      255,
+      255,
+      255
     ],
     "type": "STATIC",
-    "duration": 0.0,
-    "range": 0.0,
+    "duration": 0,
+    "range": 0,
     "fadeInDuration": 300,
     "projectileIds": [
       301
@@ -26764,13 +26764,13 @@
     "radius": 700,
     "strength": 12.5,
     "color": [
-      1.0,
-      0.20109573,
-      0.0
+      255,
+      123,
+      0
     ],
     "type": "STATIC",
-    "duration": 0.0,
-    "range": 0.0,
+    "duration": 0,
+    "range": 0,
     "fadeInDuration": 500,
     "projectileIds": [
       450
@@ -26781,13 +26781,13 @@
     "radius": 700,
     "strength": 12.5,
     "color": [
-      1.0,
-      0.20109573,
-      0.0
+      255,
+      123,
+      0
     ],
     "type": "STATIC",
-    "duration": 0.0,
-    "range": 0.0,
+    "duration": 0,
+    "range": 0,
     "fadeInDuration": 500,
     "projectileIds": [
       54
@@ -26796,15 +26796,15 @@
   {
     "description": "UNDEAD_DRUID",
     "radius": 300,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      0.31118053,
-      0.0,
-      0.0
+      150,
+      0,
+      0
     ],
     "type": "STATIC",
-    "duration": 0.0,
-    "range": 0.0,
+    "duration": 0,
+    "range": 0,
     "fadeInDuration": 1000,
     "projectileIds": [
       1679
@@ -26818,15 +26818,15 @@
     "height": 100,
     "alignment": "CENTER",
     "radius": 4000,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -26837,15 +26837,15 @@
     "height": 100,
     "alignment": "CENTER",
     "radius": 4000,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -26856,15 +26856,15 @@
     "height": 100,
     "alignment": "CENTER",
     "radius": 4000,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      0.92156863,
-      0.38039216,
-      0.09019608
+      245.70636,
+      164.33739,
+      85.43297
     ],
     "type": "PULSE",
-    "duration": 7000.0,
-    "range": 10.0,
+    "duration": 7000,
+    "range": 10,
     "fadeInDuration": 0
   },
   {
@@ -26872,15 +26872,15 @@
     "height": 80,
     "alignment": "CENTER",
     "radius": 800,
-    "strength": 20.0,
+    "strength": 20,
     "color": [
-      0.9743002,
-      0.3021255,
-      5.6921755E-5
+      252,
+      148,
+      3
     ],
     "type": "FLICKER",
-    "duration": 0.0,
-    "range": 20.0,
+    "duration": 0,
+    "range": 20,
     "objectIds": [
       "FLAMES"
     ]
@@ -26890,15 +26890,15 @@
     "height": 80,
     "alignment": "CENTER",
     "radius": 5000,
-    "strength": 30.0,
+    "strength": 30,
     "color": [
-      0.9743002,
-      0.3021255,
-      5.6921755E-5
+      252,
+      148,
+      3
     ],
     "type": "FLICKER",
-    "duration": 0.0,
-    "range": 20.0,
+    "duration": 0,
+    "range": 20,
     "objectIds": [
       "SOUL_DEVOURER"
     ]
@@ -26908,15 +26908,15 @@
     "height": 200,
     "alignment": "CENTER",
     "radius": 500,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      0.9743002,
-      0.19751643,
-      5.6921755E-5
+      252,
+      122,
+      3
     ],
     "type": "FLICKER",
-    "duration": 0.0,
-    "range": 20.0,
+    "duration": 0,
+    "range": 20,
     "npcIds": [
       "DRAGON_HEAD_8144"
     ]
@@ -26926,15 +26926,15 @@
     "height": 300,
     "alignment": "FRONT",
     "radius": 300,
-    "strength": 10.0,
+    "strength": 10,
     "color": [
-      0.9743002,
-      0.3021255,
-      5.6921755E-5
+      252,
+      148,
+      3
     ],
     "type": "FLICKER",
-    "duration": 0.0,
-    "range": 20.0,
+    "duration": 0,
+    "range": 20,
     "objectIds": [
       9746
     ]
@@ -26944,15 +26944,15 @@
     "height": 200,
     "alignment": "FRONT",
     "radius": 600,
-    "strength": 2.0,
+    "strength": 2,
     "color": [
-      0.0,
-      0.2673581,
-      1.0
+      0,
+      140,
+      255
     ],
     "type": "FLICKER",
-    "duration": 0.0,
-    "range": 30.0,
+    "duration": 0,
+    "range": 30,
     "objectIds": [
       41467
     ]
@@ -26964,13 +26964,13 @@
     "radius": 1400,
     "strength": 12.5,
     "color": [
-      0.9743002,
-      0.3021255,
-      5.6921755E-5
+      252,
+      148,
+      3
     ],
     "type": "FLICKER",
-    "duration": 0.0,
-    "range": 30.0,
+    "duration": 0,
+    "range": 30,
     "objectIds": [
       "SACRED_FORGE"
     ]
@@ -26982,13 +26982,13 @@
     "radius": 300,
     "strength": 7.5,
     "color": [
-      0.9743002,
-      0.19751643,
-      5.6921755E-5
+      252,
+      122,
+      3
     ],
     "type": "STATIC",
-    "duration": 0.0,
-    "range": 20.0,
+    "duration": 0,
+    "range": 20,
     "objectIds": [
       "ANVIL_32215",
       "ANVIL_32216",
@@ -27005,13 +27005,13 @@
     "radius": 500,
     "strength": 12.5,
     "color": [
-      0.9743002,
-      0.19751643,
-      5.6921755E-5
+      252,
+      122,
+      3
     ],
     "type": "STATIC",
-    "duration": 0.0,
-    "range": 20.0,
+    "duration": 0,
+    "range": 20,
     "objectIds": [
       "DRAGON_HEAD_32213"
     ]
@@ -27023,13 +27023,13 @@
     "radius": 300,
     "strength": 7.5,
     "color": [
-      0.9743002,
-      0.19751643,
-      5.6921755E-5
+      252,
+      122,
+      3
     ],
     "type": "STATIC",
-    "duration": 0.0,
-    "range": 20.0,
+    "duration": 0,
+    "range": 20,
     "objectIds": [
       32224,
       32222,
@@ -27041,15 +27041,15 @@
     "height": 250,
     "alignment": "CENTER",
     "radius": 1000,
-    "strength": 25.0,
+    "strength": 25,
     "color": [
-      0.9743002,
-      0.19751643,
-      5.6921755E-5
+      252,
+      122,
+      3
     ],
     "type": "FLICKER",
-    "duration": 0.0,
-    "range": 20.0,
+    "duration": 0,
+    "range": 20,
     "objectIds": [
       29899
     ]
@@ -27061,13 +27061,13 @@
     "radius": 700,
     "strength": 12.5,
     "color": [
-      0.2673581,
-      0.0,
-      0.0
+      140,
+      0,
+      0
     ],
     "type": "FLICKER",
-    "duration": 0.0,
-    "range": 30.0,
+    "duration": 0,
+    "range": 30,
     "objectIds": [
       6384
     ]
@@ -27079,13 +27079,13 @@
     "radius": 400,
     "strength": 80,
     "color": [
-      0.0,
-      0.5325205447,
-      1.0
+      0,
+      191.49066,
+      255
     ],
     "type": "PULSE",
-    "duration": 1200.0,
-    "range": 10.0,
+    "duration": 1200,
+    "range": 10,
     "objectIds": [
       43841
     ]
@@ -27098,15 +27098,15 @@
     "height": 260,
     "alignment": "CENTER",
     "radius": 2500,
-    "strength": 11.0,
+    "strength": 11,
     "color": [
-      0.0,
-      0.5325205447,
-      1.0
+      0,
+      191.49066,
+      255
     ],
     "type": "PULSE",
-    "duration": 1200.0,
-    "range": 12.0,
+    "duration": 1200,
+    "range": 12,
     "fadeInDuration": 0
   },
   {
@@ -27116,15 +27116,15 @@
     "radius": 300,
     "strength": 5.5,
     "color": [
-      1.0,
-      1.0,
-      0.0
+      255,
+      255,
+      0
     ],
     "type": "FLICKER",
-    "duration": 0.0,
-    "range": 0.0,
+    "duration": 0,
+    "range": 0,
     "objectIds": [
-      43695
+      "REWARDS_GUARDIAN"
     ]
   },
   {
@@ -27132,17 +27132,17 @@
     "height": 220,
     "alignment": "CENTER",
     "radius": 180,
-    "strength": 11.0,
+    "strength": 11,
     "color": [
-      0.0,
-      0.4,
-      1.0
+      0,
+      168.1351,
+      255
     ],
     "type": "FLICKER",
-    "duration": 0.0,
-    "range": 5.0,
+    "duration": 0,
+    "range": 5,
     "objectIds": [
-      43696
+      "DEPOSIT_POOL"
     ]
   },
   {
@@ -27152,15 +27152,15 @@
     "radius": 150,
     "strength": 7.7,
     "color": [
-      1.0,
-      0.4811565051,
-      0.0
+      255,
+      182.86261,
+      0
     ],
     "type": "FLICKER",
-    "duration": 0.0,
-    "range": 10.0,
+    "duration": 0,
+    "range": 10,
     "objectIds": [
-      43704
+      "GUARDIAN_OF_FIRE"
     ]
   },
   {
@@ -27170,15 +27170,15 @@
     "radius": 150,
     "strength": 7.7,
     "color": [
-      0.0,
-      1.0,
-      0.0
+      0,
+      255,
+      0
     ],
     "type": "FLICKER",
-    "duration": 0.0,
-    "range": 10.0,
+    "duration": 0,
+    "range": 10,
     "objectIds": [
-      43711
+      "GUARDIAN_OF_NATURE"
     ]
   },
   {
@@ -27188,15 +27188,15 @@
     "radius": 150,
     "strength": 7.7,
     "color": [
-      0.587219907,
-      0.4811565051,
-      0.0
+      200.19334,
+      182.86261,
+      0
     ],
     "type": "FLICKER",
-    "duration": 0.0,
-    "range": 10.0,
+    "duration": 0,
+    "range": 10,
     "objectIds": [
-      43703
+      "GUARDIAN_OF_EARTH"
     ]
   },
   {
@@ -27206,15 +27206,15 @@
     "radius": 150,
     "strength": 7.7,
     "color": [
-      0.0,
-      0.0,
-      1.0
+      0,
+      0,
+      255
     ],
     "type": "FLICKER",
-    "duration": 0.0,
-    "range": 10.0,
+    "duration": 0,
+    "range": 10,
     "objectIds": [
-      43702
+      "GUARDIAN_OF_WATER"
     ]
   },
   {
@@ -27224,15 +27224,15 @@
     "radius": 150,
     "strength": 7.7,
     "color": [
-      1.0,
-      1.0,
-      0.0
+      255,
+      255,
+      0
     ],
     "type": "FLICKER",
-    "duration": 0.0,
-    "range": 10.0,
+    "duration": 0,
+    "range": 10,
     "objectIds": [
-      43710
+      "GUARDIAN_OF_COSMIC"
     ]
   },
   {
@@ -27242,15 +27242,15 @@
     "radius": 150,
     "strength": 7.7,
     "color": [
-      1.0,
-      1.0,
-      1.0
+      255,
+      255,
+      255
     ],
     "type": "FLICKER",
-    "duration": 0.0,
-    "range": 10.0,
+    "duration": 0,
+    "range": 10,
     "objectIds": [
-      43701
+      "GUARDIAN_OF_AIR"
     ]
   },
   {
@@ -27260,15 +27260,15 @@
     "radius": 150,
     "strength": 7.7,
     "color": [
-      1.0,
-      0.6667955029,
-      0.0
+      255,
+      212.09813,
+      0
     ],
     "type": "FLICKER",
-    "duration": 0.0,
-    "range": 10.0,
+    "duration": 0,
+    "range": 10,
     "objectIds": [
-      43705
+      "GUARDIAN_OF_MIND"
     ]
   },
   {
@@ -27278,15 +27278,15 @@
     "radius": 150,
     "strength": 7.7,
     "color": [
-      0.3511191734,
-      0.3511191734,
-      1.0
+      158.46326,
+      158.46326,
+      255
     ],
     "type": "FLICKER",
-    "duration": 0.0,
-    "range": 10.0,
+    "duration": 0,
+    "range": 10,
     "objectIds": [
-      43709
+      "GUARDIAN_OF_BODY"
     ]
   },
   {
@@ -27296,15 +27296,15 @@
     "radius": 150,
     "strength": 7.7,
     "color": [
-      1.0,
-      0.6667955029,
-      0.4811565051
+      255,
+      212.09813,
+      182.86261
     ],
     "type": "FLICKER",
-    "duration": 0.0,
-    "range": 10.0,
+    "duration": 0,
+    "range": 10,
     "objectIds": [
-      43706
+      "GUARDIAN_OF_CHAOS"
     ]
   },
   {
@@ -27314,15 +27314,15 @@
     "radius": 150,
     "strength": 7.7,
     "color": [
-      0.8503349277,
-      0.8503349277,
-      0.8503349277
+      236.88396,
+      236.88396,
+      236.88396
     ],
     "type": "FLICKER",
-    "duration": 0.0,
-    "range": 10.0,
+    "duration": 0,
+    "range": 10,
     "objectIds": [
-      43707
+      "GUARDIAN_OF_DEATH"
     ]
   },
   {
@@ -27332,15 +27332,15 @@
     "radius": 150,
     "strength": 7.7,
     "color": [
-      0.4811565051,
-      0.4811565051,
-      1.0
+      182.86261,
+      182.86261,
+      255
     ],
     "type": "FLICKER",
-    "duration": 0.0,
-    "range": 10.0,
+    "duration": 0,
+    "range": 10,
     "objectIds": [
-      43712
+      "GUARDIAN_OF_LAW"
     ]
   },
   {
@@ -27350,15 +27350,15 @@
     "radius": 150,
     "strength": 7.7,
     "color": [
-      1.0,
-      0.0,
-      0.0
+      255,
+      0,
+      0
     ],
     "type": "FLICKER",
-    "duration": 0.0,
-    "range": 10.0,
+    "duration": 0,
+    "range": 10,
     "objectIds": [
-      43708
+      "GUARDIAN_OF_BLOOD"
     ]
   },
   {
@@ -27368,15 +27368,15 @@
     "radius": 200,
     "strength": 5.5,
     "color": [
-      1.0,
-      0.8774243147,
-      0.0
+      255,
+      240.28485,
+      0
     ],
     "type": "FLICKER",
-    "duration": 0.0,
-    "range": 10.0,
+    "duration": 0,
+    "range": 10,
     "objectIds": [
-      43729,
+      "PORTAL_43729",
       38044
     ]
   },
@@ -27387,16 +27387,16 @@
     "radius": 2000,
     "strength": 25,
     "color": [
-      0.9580373726,
-      0.3511191734,
-      1.0
+      250.07925,
+      158.46326,
+      255
     ],
     "type": "PULSE",
-    "duration": 1200.0,
-    "range": 15.0,
+    "duration": 1200,
+    "range": 15,
     "objectIds": [
-      43713,
-      43714
+      "ABYSSAL_RIFT_43713",
+      "ABYSSAL_RIFT_43714"
     ]
   },
   {
@@ -27404,17 +27404,17 @@
     "height": 250,
     "alignment": "CENTER",
     "radius": 350,
-    "strength": 4.0,
+    "strength": 4,
     "color": [
-      1.0,
-      1.0,
-      0.0
+      255,
+      255,
+      0
     ],
     "type": "FLICKER",
-    "duration": 0.0,
-    "range": 10.0,
+    "duration": 0,
+    "range": 10,
     "objectIds": [
-      43700
+      "BARRIER_43700"
     ]
   },
   {
@@ -27422,17 +27422,17 @@
     "height": 250,
     "alignment": "CENTER",
     "radius": 350,
-    "strength": 6.0,
+    "strength": 6,
     "color": [
-      1.0,
-      0.0,
-      0.0
+      255,
+      0,
+      0
     ],
     "type": "FLICKER",
-    "duration": 0.0,
-    "range": 10.0,
+    "duration": 0,
+    "range": 10,
     "objectIds": [
-      43849
+      "BARRIER_43849"
     ]
   },
   {
@@ -27442,16 +27442,16 @@
     "radius": 250,
     "strength": 0.75,
     "color": [
-      1.0,
-      1.0,
-      0.0
+      255,
+      255,
+      0
     ],
     "type": "FLICKER",
-    "duration": 0.0,
-    "range": 10.0,
+    "duration": 0,
+    "range": 10,
     "objectIds": [
-      43744,
-      43745
+      "WEAK_BARRIER",
+      "WEAK_BARRIER_43745"
     ]
   },
   {
@@ -27461,16 +27461,16 @@
     "radius": 250,
     "strength": 1.5,
     "color": [
-      1.0,
-      1.0,
-      0.0
+      255,
+      255,
+      0
     ],
     "type": "FLICKER",
-    "duration": 0.0,
-    "range": 10.0,
+    "duration": 0,
+    "range": 10,
     "objectIds": [
-      43746,
-      43747
+      "MEDIUM_BARRIER",
+      "MEDIUM_BARRIER_43747"
     ]
   },
   {
@@ -27480,16 +27480,16 @@
     "radius": 250,
     "strength": 2.25,
     "color": [
-      1.0,
-      1.0,
-      0.0
+      255,
+      255,
+      0
     ],
     "type": "FLICKER",
-    "duration": 0.0,
-    "range": 10.0,
+    "duration": 0,
+    "range": 10,
     "objectIds": [
-      43748,
-      43749
+      "STRONG_BARRIER",
+      "STRONG_BARRIER_43749"
     ]
   },
   {
@@ -27497,18 +27497,18 @@
     "height": 200,
     "alignment": "CENTER",
     "radius": 250,
-    "strength": 3.0,
+    "strength": 3,
     "color": [
-      1.0,
-      1.0,
-      0.0
+      255,
+      255,
+      0
     ],
     "type": "FLICKER",
-    "duration": 0.0,
-    "range": 5.0,
+    "duration": 0,
+    "range": 5,
     "objectIds": [
-      43750,
-      43751
+      "OVERCHARGED_BARRIER",
+      "OVERCHARGED_BARRIER_43751"
     ]
   },
   {
@@ -27518,15 +27518,15 @@
     "radius": 100,
     "strength": 2,
     "color": [
-      1.0,
-      1.0,
-      1.0
+      255,
+      255,
+      255
     ],
     "type": "FLICKER",
-    "duration": 0.0,
-    "range": 5.0,
+    "duration": 0,
+    "range": 5,
     "objectIds": [
-      43740
+      "WEAK_CELL_TILE"
     ]
   },
   {
@@ -27536,15 +27536,15 @@
     "radius": 100,
     "strength": 2.75,
     "color": [
-      0.0,
-      0.0,
-      1.0
+      0,
+      0,
+      255
     ],
     "type": "FLICKER",
-    "duration": 0.0,
-    "range": 5.0,
+    "duration": 0,
+    "range": 5,
     "objectIds": [
-      43741
+      "MEDIUM_CELL_TILE"
     ]
   },
   {
@@ -27554,15 +27554,15 @@
     "radius": 100,
     "strength": 2.75,
     "color": [
-      0.0,
-      1.0,
-      0.0
+      0,
+      255,
+      0
     ],
     "type": "FLICKER",
-    "duration": 0.0,
-    "range": 5.0,
+    "duration": 0,
+    "range": 5,
     "objectIds": [
-      43742
+      "STRONG_CELL_TILE"
     ]
   },
   {
@@ -27572,15 +27572,15 @@
     "radius": 100,
     "strength": 2.75,
     "color": [
-      1.0,
-      0.0,
-      0.0
+      255,
+      0,
+      0
     ],
     "type": "FLICKER",
-    "duration": 0.0,
-    "range": 5.0,
+    "duration": 0,
+    "range": 5,
     "objectIds": [
-      43743
+      "OVERPOWERED_CELL_TILE"
     ]
   }
 ]

--- a/src/test/java/rs117/hd/lighting/ExportLightsToJson.java
+++ b/src/test/java/rs117/hd/lighting/ExportLightsToJson.java
@@ -2,6 +2,8 @@ package rs117.hd.lighting;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.google.gson.JsonPrimitive;
+import com.google.gson.JsonSerializer;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -16,107 +18,232 @@ import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
+import joptsimple.ArgumentAcceptingOptionSpec;
+import joptsimple.OptionParser;
+import joptsimple.OptionSet;
+import joptsimple.OptionSpec;
+import rs117.hd.HDUtils;
 
+@SuppressWarnings("deprecation")
 public class ExportLightsToJson
 {
+	/**
+	 * Round floats to an int if they are within this small value of a whole number
+	 */
+	private static final float eps = .00001f;
+
 	public static void main(String[] args) throws IOException
 	{
-		final Path outputPath = Paths.get(
-			"src/main/resources",
-			rs117.hd.lighting.Light.class.getPackage().getName().replace(".", "/"),
-			"lights.json");
+		OptionParser parser = new OptionParser();
+		OptionSpec<?> linearToGammaOption = parser.accepts("linear1-to-gamma255",
+			"Convert current light configuration from linear colors " +
+			"in the range [0, 1] to gamma colors in the range [0, 255]");
+		ArgumentAcceptingOptionSpec<String> configPathOption = parser.accepts("config",
+				"Path to lights.json file to read from and write to")
+			.withRequiredArg()
+			.defaultsTo(Paths.get(
+					"src/main/resources",
+					Light.class.getPackage().getName().replace(".", "/"),
+					"lights.json")
+				.toString());
+		OptionSpec<?> skipLoadingCurrentConfig = parser.accepts("skip-loading-current-config",
+			"Don't load current lights from the JSON config, instead overwrite them");
+		OptionSpec<?> convertOldFormats = parser.accepts("convert-old-formats",
+			"Load lights from the old formats and convert to JSON format");
+		OptionSpec<?> serializeNulls = parser.accepts("serialize-nulls",
+			"Include null values when writing to JSON");
+		OptionSpec<?> minify = parser.accepts("minify", "Output minified JSON");
+		OptionSpec<?> disableValidationOption = parser.accepts("disable-validation", "Skip ");
+		OptionSpec<?> dryRun = parser.accepts("dry-run", "Don't write the resulting JSON to file");
+
+		OptionSet options = parser.parse(args);
+		Path configPath = Paths.get(options.valueOf(configPathOption));
+		boolean enableValidation = !options.has(disableValidationOption);
 
 		Set<Light> uniqueLights = new LinkedHashSet<>();
 
-		// Load all lights from current lights.json
-		Light.THROW_WHEN_PARSING_FAILS = true;
-		Light[] currentLights = LightConfig.loadRawLights(new FileInputStream(outputPath.toFile()));
-		Collections.addAll(uniqueLights, currentLights);
+		if (!options.has(skipLoadingCurrentConfig))
+		{
+			System.out.println("Loading current lights from JSON...");
+			// Load all lights from current lights.json
+			Light.THROW_WHEN_PARSING_FAILS = true;
+			Light[] currentLights = LightConfig.loadRawLights(new FileInputStream(configPath.toFile()));
+			Collections.addAll(uniqueLights, currentLights);
+			System.out.println("Loaded " + currentLights.length + " lights");
+		}
 
-		Gson gson = new GsonBuilder()
-//			.serializeNulls()
-			.setPrettyPrinting()
-			.create();
+		if (options.has(convertOldFormats))
+		{
+			System.out.println("Loading old lights from old formats...");
 
-		ArrayList<Light> sceneLights = LightConfigParser.loadLightsFromFile(true);
-		uniqueLights.addAll(sceneLights.stream()
-			.map(l -> new Light(
-				l.description,
-				l.worldX, l.worldY, l.plane, l.height,
-				l.alignment,
-				l.radius,
-				l.strength,
-				l.color,
-				l.type,
-				l.duration,
-				l.range,
-				l.fadeInDuration,
-				null, null, null))
-			.collect(Collectors.toList()));
+			ArrayList<Light> sceneLights = LightConfigParser.loadLightsFromFile(true);
+			uniqueLights.addAll(sceneLights.stream()
+				.map(l -> new Light(
+					l.description,
+					l.worldX, l.worldY, l.plane, l.height,
+					l.alignment,
+					l.radius,
+					l.strength,
+					l.color,
+					l.type,
+					l.duration,
+					l.range,
+					l.fadeInDuration,
+					null, null, null))
+				.collect(Collectors.toList()));
+			System.out.println("Loaded " + sceneLights.size() + " lights from old txt format");
 
-		uniqueLights.addAll(Arrays.stream(NpcLight.values())
-			.map(l -> new Light(
-				l.name(),
-				null, null, null, l.getHeight(),
-				l.getAlignment(),
-				l.getSize(),
-				l.getStrength(),
-				l.getColor(),
-				l.getLightType(),
-				l.getDuration(),
-				l.getRange(),
-				null,
-				toSet(l.getId()),
-				null,
-				null))
-			.collect(Collectors.toList()));
+			uniqueLights.addAll(Arrays.stream(NpcLight.values())
+				.map(l -> new Light(
+					l.name(),
+					null, null, null, l.getHeight(),
+					l.getAlignment(),
+					l.getSize(),
+					l.getStrength(),
+					l.getColor(),
+					l.getLightType(),
+					l.getDuration(),
+					l.getRange(),
+					null,
+					toSet(l.getId()),
+					null,
+					null))
+				.collect(Collectors.toList()));
+			System.out.println("Loaded " + NpcLight.values().length + " lights from old NpcLight enum");
 
-		uniqueLights.addAll(Arrays.stream(ObjectLight.values())
-			.map(l -> new Light(
-				l.name(),
-				null, null, null, l.getHeight(),
-				l.getAlignment(),
-				l.getSize(),
-				l.getStrength(),
-				l.getColor(),
-				l.getLightType(),
-				l.getDuration(),
-				l.getRange(),
-				null,
-				null,
-				toSet(l.getId()),
-				null))
-			.collect(Collectors.toList()));
+			uniqueLights.addAll(Arrays.stream(ObjectLight.values())
+				.map(l -> new Light(
+					l.name(),
+					null, null, null, l.getHeight(),
+					l.getAlignment(),
+					l.getSize(),
+					l.getStrength(),
+					l.getColor(),
+					l.getLightType(),
+					l.getDuration(),
+					l.getRange(),
+					null,
+					null,
+					toSet(l.getId()),
+					null))
+				.collect(Collectors.toList()));
+			System.out.println("Loaded " + ObjectLight.values().length + " lights from old ObjectLight enum");
 
-		uniqueLights.addAll(Arrays.stream(ProjectileLight.values())
-			.map(l -> new Light(
-				l.name(),
-				null, null, null, null,
-				null,
-				l.getSize(),
-				l.getStrength(),
-				l.getColor(),
-				l.getLightType(),
-				l.getDuration(),
-				l.getRange(),
-				l.getFadeInDuration(),
-				null,
-				null,
-				toSet(l.getId())))
-			.collect(Collectors.toList()));
+			uniqueLights.addAll(Arrays.stream(ProjectileLight.values())
+				.map(l -> new Light(
+					l.name(),
+					null, null, null, null,
+					null,
+					l.getSize(),
+					l.getStrength(),
+					l.getColor(),
+					l.getLightType(),
+					l.getDuration(),
+					l.getRange(),
+					l.getFadeInDuration(),
+					null,
+					null,
+					toSet(l.getId())))
+				.collect(Collectors.toList()));
+			System.out.println("Loaded " + ProjectileLight.values().length + " lights from old ProjectileLight enum");
+		}
 
-		// Write combined lights.json
-		String json = gson.toJson(uniqueLights);
+		if (options.has(linearToGammaOption))
+		{
+			enableValidation = false;
+			System.out.println("Converting colors from linear color space in the range [0, 1] to gamma [0, 255]");
 
-		System.out.println("Writing config for " + uniqueLights.size() + " lights to " + outputPath.toAbsolutePath());
-		outputPath.toFile().getParentFile().mkdirs();
+			for (Light l : uniqueLights)
+			{
+				for (int i = 0; i < l.color.length; i++)
+				{
+					l.color[i] = HDUtils.linearToGamma(l.color[i]) * 255f;
+					int nearestInt = Math.round(l.color[i]);
+					if (Math.abs(nearestInt - l.color[i]) <= eps)
+					{
+						l.color[i] = nearestInt;
+					}
+				}
+			}
+		}
 
-		OutputStreamWriter os = new OutputStreamWriter(
-			new FileOutputStream(outputPath.toFile()),
-			StandardCharsets.UTF_8);
+		if (enableValidation)
+		{
+			for (Light l : uniqueLights)
+			{
+				// TODO: Potentially allow alpha component if it at some point ends up actually being used
+				// TODO: Consider allowing colors outside the normal range, either for darkness lights or HDR
 
-		os.write(json);
-		os.close();
+				if (l.color.length > 3)
+				{
+					System.err.printf("More than 3 colors provided for light '%s'%n", l.description);
+				}
+
+				boolean allBelow1 = true;
+				boolean invalidRange = false;
+				for (float c : l.color)
+				{
+					// Warn if all values are at or below 1, indicating a possible mistake
+					allBelow1 = allBelow1 && c <= 1;
+					// Also warn if values lie outside the expected range
+					invalidRange = invalidRange || c < 0 || c > 255;
+				}
+
+				if (allBelow1)
+				{
+					System.err.printf("Probable incorrect color range for light: '%s'. " +
+						"Should be 0-255. Actual values are all close to zero: %s",
+						l.description, Arrays.toString(l.color));
+				}
+
+				if (invalidRange)
+				{
+					System.err.printf("One or more colors in light '%s' lie outside the normal range of 0 to 255: %s%n",
+						l.description, Arrays.toString(l.color));
+				}
+			}
+		}
+
+		if (!options.has(dryRun))
+		{
+			GsonBuilder gsonBuilder = new GsonBuilder()
+				.disableHtmlEscaping(); // Allow characters like apostrophes in descriptions
+
+			if (!options.has(minify))
+			{
+				gsonBuilder.setPrettyPrinting();
+			}
+			if (options.has(serializeNulls))
+			{
+				gsonBuilder.serializeNulls();
+			}
+
+			// Strip unnecessary decimals
+			gsonBuilder.registerTypeAdapter(Float.class, (JsonSerializer<Float>) (src, typeOfSrc, context) ->
+			{
+				int nearestInt = Math.round(src);
+				if (Math.abs(src - nearestInt) <= eps)
+				{
+					return new JsonPrimitive(nearestInt);
+				}
+				return new JsonPrimitive(src);
+			});
+
+			Gson gson = gsonBuilder.create();
+
+			// Write combined lights.json
+			String json = gson.toJson(uniqueLights);
+
+			System.out.println("Writing " + uniqueLights.size() + " lights to JSON file: " + configPath.toAbsolutePath());
+			configPath.toFile().getParentFile().mkdirs();
+
+			OutputStreamWriter os = new OutputStreamWriter(
+				new FileOutputStream(configPath.toFile()),
+				StandardCharsets.UTF_8);
+
+			os.write(json);
+			os.close();
+		}
 	}
 
 	private static HashSet<Integer> toSet(int[] ints)

--- a/src/test/java/rs117/hd/lighting/LightConfigTest.java
+++ b/src/test/java/rs117/hd/lighting/LightConfigTest.java
@@ -2,6 +2,12 @@ package rs117.hd.lighting;
 
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.ListMultimap;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -14,9 +20,28 @@ public class LightConfigTest {
     private static final ListMultimap<Integer, Light> OBJECT_LIGHTS = ArrayListMultimap.create();
     private static final ListMultimap<Integer, Light> PROJECTILE_LIGHTS = ArrayListMultimap.create();
 
-    @Test
+	private final ByteArrayOutputStream stderr = new ByteArrayOutputStream();
+	private final ByteArrayOutputStream stdout = new ByteArrayOutputStream();
+	private final PrintStream originalStdout = System.out;
+	private final PrintStream originalStderr = System.err;
+
+	@Before
+	public void setupStreams() {
+		System.setOut(new PrintStream(stdout));
+		System.setErr(new PrintStream(stderr));
+	}
+
+	@After
+	public void restoreStreams() {
+		System.setErr(originalStdout);
+		System.setErr(originalStderr);
+	}
+
+	@Test
     public void testLoad() {
-        LightConfig.load(Thread.currentThread().getContextClassLoader().getResourceAsStream("lighting/lights.json"), WORLD_LIGHTS, NPC_LIGHTS, OBJECT_LIGHTS, PROJECTILE_LIGHTS);
+        LightConfig.load(Thread.currentThread().getContextClassLoader()
+			.getResourceAsStream("lighting/lights.json"),
+			WORLD_LIGHTS, NPC_LIGHTS, OBJECT_LIGHTS, PROJECTILE_LIGHTS);
 
         // can we get the same light for both of its raw IDs?
         Light spitRoastLight = OBJECT_LIGHTS.get(5608).get(0);
@@ -35,4 +60,11 @@ public class LightConfigTest {
         assertEquals(0.3021255, spitRoastLight.color[1], 0.001);
         assertEquals(5.6921755E-5, spitRoastLight.color[2], 0.001);
     }
+
+	@Test
+	public void validateLightsConfig() throws IOException
+	{
+		ExportLightsToJson.main(new String[] { "--dry-run" });
+		Assert.assertEquals(stderr.toString(), "");
+	}
 }

--- a/src/test/resources/lighting/lights.json
+++ b/src/test/resources/lighting/lights.json
@@ -6,16 +6,16 @@
     "radius": 250,
     "strength": 12.5,
     "color": [
-      0.9743002,
-      0.3021255,
-      5.6921755E-5
+      252,
+      148,
+      3
     ],
     "type": "FLICKER",
-    "duration": 0.0,
-    "range": 20.0,
+    "duration": 0,
+    "range": 20,
     "objectIds": [
       "SPIT_ROAST_5608",
       "SPIT_ROAST"
     ]
   }
-]
+]


### PR DESCRIPTION
This converts color values from linear color space in the range [0, 1] into gamma color space in the range [0, 255] to make manually configuring light colors in the JSON config more intuitive, matching values from a typical color picker. The numbers are still floats, so decimals are still supported, but I figured I would also strip unnecessary decimals in the conversion process, leaving color values looking more like those in the old formats. Colors are still in linear color space after they've been loaded from the JSON.

Summary of changes:
- Changes to `ExportLightsToJson`:
  - Add various command line arguments (e.g. `--dry-run` option for testing).
  - Error when more than 3 color values are provided, since the alpha channel is currently unused.
  - Error when all 3 values of a color are below 1, indicating that they're possibly in the old format, since practically black lights are unlikely.
  - Error when colors lie outside of the expected range from 0 to 255.
- Add validation of the main `lights.json` config to `LightConfigTest` using `ExportLightsToJson`'s `--dry-run` option.
- Remove unnecessary HTML character escaping from the JSON, since it was escaping things like the apostrophe in `Gu'Tanoth`.