### PR TITLE
Enable DebugGL when running with debug logging

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ dependencies {
 }
 
 group = 'rs117.hd'
-version = '1.0.14'
+version = '1.0.14.1'
 sourceCompatibility = '1.8'
 
 tasks.withType(JavaCompile) {

--- a/build.gradle
+++ b/build.gradle
@@ -11,9 +11,11 @@ repositories {
 }
 
 def runeLiteVersion = '1.8.14-SNAPSHOT'
+def joglVersion = '2.4.0-rc-20220318'
 
 dependencies {
 	compileOnly group: 'net.runelite', name:'client', version: runeLiteVersion
+	compileOnly group: 'net.runelite.jogl', name:'jogl-gldesktop-dbg', version: joglVersion
 
 	compileOnly 'org.projectlombok:lombok:1.18.20'
 	annotationProcessor 'org.projectlombok:lombok:1.18.20'
@@ -21,6 +23,7 @@ dependencies {
 	testImplementation 'junit:junit:4.12'
 	testImplementation group: 'net.runelite', name:'client', version: runeLiteVersion
 	testImplementation group: 'net.runelite', name:'jshell', version: runeLiteVersion
+	testImplementation group: 'net.runelite.jogl', name:'jogl-gldesktop-dbg', version: joglVersion
 
 	testCompileOnly 'org.projectlombok:lombok:1.18.20'
 	testAnnotationProcessor 'org.projectlombok:lombok:1.18.20'

--- a/src/main/java/rs117/hd/HdPlugin.java
+++ b/src/main/java/rs117/hd/HdPlugin.java
@@ -31,6 +31,7 @@ import com.jogamp.nativewindow.AbstractGraphicsConfiguration;
 import com.jogamp.nativewindow.NativeWindowFactory;
 import com.jogamp.nativewindow.awt.AWTGraphicsConfiguration;
 import com.jogamp.nativewindow.awt.JAWTWindow;
+import com.jogamp.opengl.DebugGL4;
 import com.jogamp.opengl.GL;
 import static com.jogamp.opengl.GL.*;
 import static com.jogamp.opengl.GL2ES2.GL_STREAM_DRAW;
@@ -564,6 +565,15 @@ public class HdPlugin extends Plugin implements DrawCallbacks
 
 					if (log.isDebugEnabled())
 					{
+						try
+						{
+							gl = new DebugGL4(gl);
+						}
+						catch (NoClassDefFoundError ex)
+						{
+							log.debug("Disabling DebugGL due to jogl-gldesktop-dbg not being present on the classpath");
+						}
+
 						gl.glEnable(gl.GL_DEBUG_OUTPUT);
 
 						//	GLDebugEvent[ id 0x20071

--- a/src/main/java/rs117/hd/HdPlugin.java
+++ b/src/main/java/rs117/hd/HdPlugin.java
@@ -27,6 +27,8 @@ package rs117.hd;
 
 import com.google.common.primitives.Ints;
 import com.google.inject.Provides;
+import com.jogamp.nativewindow.AbstractGraphicsConfiguration;
+import com.jogamp.nativewindow.NativeWindowFactory;
 import com.jogamp.nativewindow.awt.AWTGraphicsConfiguration;
 import com.jogamp.nativewindow.awt.JAWTWindow;
 import com.jogamp.opengl.GL;
@@ -69,7 +71,6 @@ import javax.swing.SwingUtilities;
 import jogamp.nativewindow.SurfaceScaleUtils;
 import jogamp.nativewindow.jawt.x11.X11JAWTWindow;
 import jogamp.nativewindow.macosx.OSXUtil;
-import jogamp.newt.awt.NewtFactoryAWT;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.*;
@@ -522,7 +523,7 @@ public class HdPlugin extends Plugin implements DrawCallbacks
 
 					AWTGraphicsConfiguration config = AWTGraphicsConfiguration.create(canvas.getGraphicsConfiguration(), glCaps, glCaps);
 
-					jawtWindow = NewtFactoryAWT.getNativeWindow(canvas, config);
+					jawtWindow = (JAWTWindow) NativeWindowFactory.getNativeWindow(canvas, config);
 					canvas.setFocusable(true);
 
 					GLDrawableFactory glDrawableFactory = GLDrawableFactory.getFactory(glProfile);
@@ -717,7 +718,9 @@ public class HdPlugin extends Plugin implements DrawCallbacks
 					// we'll just leak the window...
 					if (OSType.getOSType() != OSType.MacOS)
 					{
-						NewtFactoryAWT.destroyNativeWindow(jawtWindow);
+						final AbstractGraphicsConfiguration config = jawtWindow.getGraphicsConfiguration();
+						jawtWindow.destroy();
+						config.getScreen().getDevice().close();
 					}
 				}
 			});

--- a/src/main/java/rs117/hd/OpenCLManager.java
+++ b/src/main/java/rs117/hd/OpenCLManager.java
@@ -35,12 +35,10 @@ import java.util.Objects;
 import javax.inject.Singleton;
 import jogamp.opengl.GLContextImpl;
 import jogamp.opengl.GLDrawableImpl;
-import jogamp.opengl.egl.EGLContext;
 import jogamp.opengl.macosx.cgl.CGL;
 import jogamp.opengl.windows.wgl.WindowsWGLContext;
 import jogamp.opengl.x11.glx.X11GLXContext;
 import lombok.extern.slf4j.Slf4j;
-import net.runelite.client.plugins.gpu.GpuPlugin;
 import net.runelite.client.plugins.gpu.template.Template;
 import net.runelite.client.util.OSType;
 import org.jocl.CL;
@@ -306,12 +304,6 @@ class OpenCLManager
 			long surfaceHandle = nativeSurface.getSurfaceHandle();
 			contextProps.addProperty(CL_GL_CONTEXT_KHR, glContextHandle);
 			contextProps.addProperty(CL_WGL_HDC_KHR, surfaceHandle);
-		}
-		else if (glContext instanceof EGLContext)
-		{
-			long displayHandle = nativeSurface.getDisplayHandle();
-			contextProps.addProperty(CL_GL_CONTEXT_KHR, glContextHandle);
-			contextProps.addProperty(CL_EGL_DISPLAY_KHR, displayHandle);
 		}
 
 		log.debug("Creating context with props: {}", contextProps);


### PR DESCRIPTION
This wraps the `GL4` instance in `DebugGL4` when the plugin is turned on while debug logging is enabled, if it is present on the classpath. When launching HD through `HdPluginTest`, `DebugGL4` is added to the classpath by Gradle.

Why? [`DebugGL4`](https://jogamp.org/deployment/jogamp-next/javadoc/jogl/javadoc/com/jogamp/opengl/DebugGL4.html) intercepts all GL calls and checks if OpenGL reported an error after the call, and if so, it throws an exception. This can be quite helpful with tracking down invalid GL calls that otherwise go unnoticed.

Depends on #261