### PR TITLE
Disable default winter theme

### DIFF
--- a/src/main/java/rs117/hd/HdPluginConfig.java
+++ b/src/main/java/rs117/hd/HdPluginConfig.java
@@ -58,7 +58,7 @@ public interface HdPluginConfig extends Config
 	String limitedTimeSettings = "limitedTimeSettings";
 
 	@ConfigItem(
-		keyName = "winterTheme",
+		keyName = "winterTheme0",
 		name = "Winter theme",
 		description = "Covers the Gielinor overworld with a layer of snow!",
 		position = -9,

--- a/src/main/java/rs117/hd/HdPluginConfig.java
+++ b/src/main/java/rs117/hd/HdPluginConfig.java
@@ -66,7 +66,7 @@ public interface HdPluginConfig extends Config
 	)
 	default boolean winterTheme()
 	{
-		return true;
+		return false;
 	}
 
 


### PR DESCRIPTION
We're now 3 days into northern hemisphere spring, ~7/8'ths of people live there.

When this setting was created it was enabled for everybody, should we reset it to be turned off for everybody or only change the default for new plugin users?