### PR TITLE
Update shadow threshold

### DIFF
--- a/src/main/resources/rs117/hd/shadow_frag.glsl
+++ b/src/main/resources/rs117/hd/shadow_frag.glsl
@@ -75,7 +75,7 @@ void main()
     uv = vec2((uv.x - 0.5) / material[materialId].textureScale.x + 0.5, (uv.y - 0.5) / material[materialId].textureScale.y + 0.5);
     vec4 texture = texture(texturesHD, vec3(uv, material[materialId].diffuseMapId));
 
-    if (min(texture.a, alpha) < 0.85)
+    if (min(texture.a, alpha) < 0.81)
     {
         discard;
     }


### PR DESCRIPTION
Have to bump this down from 0.85 to 0.81 so that one of the new objects in GOTR works properly.

https://docs.google.com/spreadsheets/d/16UIcbYeTgiubOE6nnOTjvZRabG80ZuxxPxFTIcLfnwY/edit#gid=0

Will add a tick or two of shadows to the aberrant spectre animation. No great setting for this but i think this value is least-bad for now.