### PR TITLE
Fix minor shader indexing issues

### DIFF
--- a/src/main/java/rs117/hd/HdPlugin.java
+++ b/src/main/java/rs117/hd/HdPlugin.java
@@ -1803,7 +1803,7 @@ public class HdPlugin extends Plugin implements DrawCallbacks
 				// bind uniforms
 				gl.glUniformBlockBinding(glShadowProgram, uniShadowBlockMaterials, 1);
 				gl.glUniform1i(uniShadowTexturesHD, 2); // HD texture sampler array is bound to texture2
-				gl.glUniform2fv(uniShadowTextureOffsets, textureOffsets.length, textureOffsets, 0);
+				gl.glUniform2fv(uniShadowTextureOffsets, 128, textureOffsets, 0);
 
 				gl.glEnable(gl.GL_CULL_FACE);
 				gl.glEnable(gl.GL_DEPTH_TEST);

--- a/src/main/resources/rs117/hd/frag.glsl
+++ b/src/main/resources/rs117/hd/frag.glsl
@@ -355,9 +355,17 @@ void main() {
 
     vec4 fragColor = vColor1 * texBlend.x + vColor2 * texBlend.y + vColor3 * texBlend.z;
 
-    vec2 uv1 = baseUv1 + textureOffsets[diffuseMapId1];
-    vec2 uv2 = baseUv2 + textureOffsets[diffuseMapId2];
-    vec2 uv3 = baseUv3 + textureOffsets[diffuseMapId3];
+    vec2 uv1 = baseUv1;
+    vec2 uv2 = baseUv2;
+    vec2 uv3 = baseUv3;
+
+    // Fetch texture animation offsets for vanilla textures
+    if (diffuseMapId1 < 128)
+        uv1 += textureOffsets[diffuseMapId1];
+    if (diffuseMapId2 < 128)
+        uv2 += textureOffsets[diffuseMapId2];
+    if (diffuseMapId3 < 128)
+        uv3 += textureOffsets[diffuseMapId3];
 
     uv1 = vec2((uv1.x - 0.5) / material1.textureScale.x + 0.5, (uv1.y - 0.5) / material1.textureScale.y + 0.5);
     uv2 = vec2((uv2.x - 0.5) / material2.textureScale.x + 0.5, (uv2.y - 0.5) / material2.textureScale.y + 0.5);

--- a/src/main/resources/rs117/hd/frag.glsl
+++ b/src/main/resources/rs117/hd/frag.glsl
@@ -180,41 +180,41 @@ void main() {
     int waterNormalMap2 = 236;
 
     if (
-   diffuseMapId1 == 1 || diffuseMapId1 == 24 || diffuseMapId1 == 7001 || diffuseMapId1 == 7024 ||
-   diffuseMapId2 == 1 || diffuseMapId2 == 24 || diffuseMapId2 == 7001 || diffuseMapId2 == 7024 ||
-   diffuseMapId3 == 1 || diffuseMapId3 == 24 || diffuseMapId3 == 7001 || diffuseMapId3 == 7024)
+        diffuseMapId1 == 1 || diffuseMapId1 == 24 || diffuseMapId1 == 7001 || diffuseMapId1 == 7024 ||
+        diffuseMapId2 == 1 || diffuseMapId2 == 24 || diffuseMapId2 == 7001 || diffuseMapId2 == 7024 ||
+        diffuseMapId3 == 1 || diffuseMapId3 == 24 || diffuseMapId3 == 7001 || diffuseMapId3 == 7024)
     {
         isWater = true;
         waterType = WATER;
     }
     else if (
-    diffuseMapId1 == 25 || diffuseMapId1 == 7025 ||
-    diffuseMapId2 == 25 || diffuseMapId2 == 7025 ||
-    diffuseMapId3 == 25 || diffuseMapId3 == 7025)
+        diffuseMapId1 == 25 || diffuseMapId1 == 7025 ||
+        diffuseMapId2 == 25 || diffuseMapId2 == 7025 ||
+        diffuseMapId3 == 25 || diffuseMapId3 == 7025)
     {
         isWater = true;
         waterType = SWAMP_WATER;
     }
     else if (
-    diffuseMapId1 == 998 || diffuseMapId1 == 7998 ||
-    diffuseMapId2 == 998 || diffuseMapId2 == 7998 ||
-    diffuseMapId3 == 998 || diffuseMapId3 == 7998)
+        diffuseMapId1 == 998 || diffuseMapId1 == 7998 ||
+        diffuseMapId2 == 998 || diffuseMapId2 == 7998 ||
+        diffuseMapId3 == 998 || diffuseMapId3 == 7998)
     {
         isWater = true;
         waterType = POISON_WASTE;
     }
     else if (
-    diffuseMapId1 == 999 || diffuseMapId1 == 7999 ||
-    diffuseMapId2 == 999 || diffuseMapId2 == 7999 ||
-    diffuseMapId3 == 999 || diffuseMapId3 == 7999)
+        diffuseMapId1 == 999 || diffuseMapId1 == 7999 ||
+        diffuseMapId2 == 999 || diffuseMapId2 == 7999 ||
+        diffuseMapId3 == 999 || diffuseMapId3 == 7999)
     {
         isWater = true;
         waterType = BLOOD;
     }
     else if (
-    diffuseMapId1 == 997 || diffuseMapId1 == 7997 ||
-    diffuseMapId2 == 997 || diffuseMapId2 == 7997 ||
-    diffuseMapId3 == 997 || diffuseMapId3 == 7997)
+        diffuseMapId1 == 997 || diffuseMapId1 == 7997 ||
+        diffuseMapId2 == 997 || diffuseMapId2 == 7997 ||
+        diffuseMapId3 == 997 || diffuseMapId3 == 7997)
     {
         isWater = true;
         waterType = ICE;

--- a/src/main/resources/rs117/hd/shadow_frag.glsl
+++ b/src/main/resources/rs117/hd/shadow_frag.glsl
@@ -60,8 +60,10 @@ void main()
         discard;
     }
 
+    Material mat = material[materialId];
+
     // skip water surfaces
-    switch (material[materialId].diffuseMapId)
+    switch (mat.diffuseMapId)
     {
         case 7001:
         case 7025:
@@ -71,9 +73,11 @@ void main()
             discard;
     }
 
-    vec2 uv = fUv + textureOffsets[material[materialId].diffuseMapId];
-    uv = vec2((uv.x - 0.5) / material[materialId].textureScale.x + 0.5, (uv.y - 0.5) / material[materialId].textureScale.y + 0.5);
-    vec4 texture = texture(texturesHD, vec3(uv, material[materialId].diffuseMapId));
+    vec2 uv = fUv;
+    if (mat.diffuseMapId < 128)
+        uv += textureOffsets[mat.diffuseMapId];
+    uv = vec2((uv.x - 0.5) / mat.textureScale.x + 0.5, (uv.y - 0.5) / mat.textureScale.y + 0.5);
+    vec4 texture = texture(texturesHD, vec3(uv, mat.diffuseMapId));
 
     if (min(texture.a, alpha) < 0.81)
     {


### PR DESCRIPTION
Apparently we are indexing out of bounds from `uniform vec2 textureOffsets[128]` whenever `Material.diffuseMapId >= 128`. This doesn't seem to affect anything visually or performance-wise on my GPU, but maybe it's an issue on some cards.

Below shows everywhere that's indexing >= 128 in red at the GE, with the following shader code:
```glsl
// Fetch texture animation offsets for vanilla textures
if (diffuseMapId1 < 128)
    uv1 += textureOffsets[diffuseMapId1];
if (diffuseMapId2 < 128)
    uv2 += textureOffsets[diffuseMapId2];
if (diffuseMapId3 < 128)
    uv3 += textureOffsets[diffuseMapId3];

if (diffuseMapId1 >= 128 || diffuseMapId2 >= 128 || diffuseMapId3 >= 128) {
    FragColor = vec4(1, 0, 0, 1);
    return;
}
```

![image](https://user-images.githubusercontent.com/831317/160293981-b69b790c-4ca5-4d9e-a68f-b9fec1663512.png)

Other changes include:
- Formatting & cleanup
- Uploading the correct number of `vec2`'s to the shadow program's `textureOffsets` uniform (128 instead of 256).