### PR TITLE
set jogamp.gluegen.TestTempDirExec=false

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,8 +10,12 @@ repositories {
 	mavenCentral()
 }
 
+<<<<<<< Updated upstream
 def runeLiteVersion = '1.8.15-SNAPSHOT'
 def joglVersion = '2.4.0-rc-20220318'
+=======
+def runeLiteVersion = '1.8.16-SNAPSHOT'
+>>>>>>> Stashed changes
 
 dependencies {
 	compileOnly group: 'net.runelite', name:'client', version: runeLiteVersion

--- a/src/main/java/rs117/hd/HdPlugin.java
+++ b/src/main/java/rs117/hd/HdPlugin.java
@@ -494,10 +494,9 @@ public class HdPlugin extends Plugin implements DrawCallbacks
 				{
 					System.setProperty("jogl.debug", "true");
 				}
-
-				System.setProperty("jogamp.gluegen.UseNativeExeFile", "true");
-				System.setProperty("jogamp.gluegen.TestTempDirExec", "false");
 				
+				System.setProperty("jogamp.gluegen.TestTempDirExec", "false");
+
 				GLProfile.initSingleton();
 
 				invokeOnMainThread(() ->

--- a/src/main/java/rs117/hd/HdPlugin.java
+++ b/src/main/java/rs117/hd/HdPlugin.java
@@ -495,6 +495,9 @@ public class HdPlugin extends Plugin implements DrawCallbacks
 					System.setProperty("jogl.debug", "true");
 				}
 
+				System.setProperty("jogamp.gluegen.UseNativeExeFile", "true");
+				System.setProperty("jogamp.gluegen.TestTempDirExec", "false");
+				
 				GLProfile.initSingleton();
 
 				invokeOnMainThread(() ->


### PR DESCRIPTION
This prevents gluegen from testing if the tempdir is noexec, resulting
in it always using the tempdir. The test seems unreliable since we see
many users who fail the exec test but the plugin would work for
otherwise.