### PR TITLE
Fix rare race conditions with graphics/swapBuffers

### DIFF
--- a/src/main/java/rs117/hd/HdPlugin.java
+++ b/src/main/java/rs117/hd/HdPlugin.java
@@ -2091,9 +2091,15 @@ public class HdPlugin extends Plugin implements DrawCallbacks
 		// Texture on UI
 		drawUi(overlayColor, canvasHeight, canvasWidth);
 
-		glDrawable.swapBuffers();
+		try {
+			glDrawable.swapBuffers();
 
-		drawManager.processDrawComplete(this::screenshot);
+			drawManager.processDrawComplete(this::screenshot);
+		} catch (GLException ex) {
+			log.warn("swapBuffers exception", ex);
+			shutDown();
+			startUp();
+		}
 	}
 
 	private float[] makeProjectionMatrix(float w, float h, float n)
@@ -2605,6 +2611,7 @@ public class HdPlugin extends Plugin implements DrawCallbacks
 		else
 		{
 			final Graphics2D graphics = (Graphics2D) canvas.getGraphics();
+			if (graphics == null) return;
 			final AffineTransform t = graphics.getTransform();
 			gl.glViewport(
 				getScaledValue(t.getScaleX(), x),


### PR DESCRIPTION
This fixes two very rare race conditions. Sometimes loading OSRS (via RuneLite with RLHD enabled) and clicking the settings button too quickly, there is an NPE where getGraphics returns null. 

You can see getGraphics returns null in a few situations: 
![](https://i.imgur.com/JNUoCtG.png)

After fixing this, it then exposes a GLException (again, when loading via RuneLite with RLHD enabled) where it fails to swap buffers.

Again, you can see that swapBuffers throws GLException, yet we aren't currently handling that exception so if it throws that exception, it crashes RuneLite entirely (even though it's a recoverable problem by simply resetting the plugin): 
![](https://i.imgur.com/AqdpnH7.png)

I can see we have very similar handling of an exception right here: https://github.com/RS117/RLHD/blob/master/src/main/java/rs117/hd/HdPlugin.java#L1661 and we also reset the plugin here: https://github.com/RS117/RLHD/blob/master/src/main/java/rs117/hd/HdPlugin.java#L1640

IMO this is a fairly low risk high reward fix for a very rare race condition that likely doesn't affect very many people at all, but I think it's still worth having. 