### PR TITLE
Tweak lamp

### DIFF
--- a/src/main/resources/rs117/hd/lighting/lights.json
+++ b/src/main/resources/rs117/hd/lighting/lights.json
@@ -25333,12 +25333,12 @@
     "description": "RED_STREET_LAMP",
     "height": 250,
     "alignment": "CENTER",
-    "radius": 300,
-    "strength": 7.5,
+    "radius": 500,
+    "strength": 5,
     "color": [
       255,
-      0,
-      0
+      100,
+      100
     ],
     "type": "FLICKER",
     "duration": 0,


### PR DESCRIPTION
Adjust the red Darkmeyer street lamp so that it reaches the ground, nearby buildings and objects more effectively. Also changes the light color to be a bit whiter than pure red.

https://cdn.knightlab.com/libs/juxtapose/latest/embed/index.html?uid=dad7fb3a-c98c-11ec-b5bb-6595d9b17862

"Solid improvement, really adds to the ambiance!" - Keyosk
"i love it" - breakthetargets