### PR TITLE
Fix cleanup after compilation error & other minor fixes

### DIFF
--- a/src/main/java/rs117/hd/HdPlugin.java
+++ b/src/main/java/rs117/hd/HdPlugin.java
@@ -209,26 +209,26 @@ public class HdPlugin extends Plugin implements DrawCallbacks
 		.add(GL4.GL_VERTEX_SHADER, "vertui.glsl")
 		.add(GL4.GL_FRAGMENT_SHADER, "fragui.glsl");
 
-	private int glProgram;
-	private int glComputeProgram;
-	private int glSmallComputeProgram;
-	private int glUnorderedComputeProgram;
-	private int glUiProgram;
-	private int glShadowProgram;
+	private int glProgram = -1;
+	private int glComputeProgram = -1;
+	private int glSmallComputeProgram = -1;
+	private int glUnorderedComputeProgram = -1;
+	private int glUiProgram = -1;
+	private int glShadowProgram = -1;
 
-	private int vaoHandle;
+	private int vaoHandle = -1;
 
-	private int interfaceTexture;
-	private int interfacePbo;
+	private int interfaceTexture = -1;
+	private int interfacePbo = -1;
 
-	private int vaoUiHandle;
-	private int vboUiHandle;
+	private int vaoUiHandle = -1;
+	private int vboUiHandle = -1;
 
-	private int fboSceneHandle;
-	private int rboSceneHandle;
+	private int fboSceneHandle = -1;
+	private int rboSceneHandle = -1;
 
-	private int fboShadowMap;
-	private int texShadowMap;
+	private int fboShadowMap = -1;
+	private int texShadowMap = -1;
 
 	// scene vertex buffer
 	private final GLBuffer sceneVertexBuffer = new GLBuffer();
@@ -914,23 +914,41 @@ public class HdPlugin extends Plugin implements DrawCallbacks
 
 	private void shutdownProgram()
 	{
-		gl.glDeleteProgram(glProgram);
-		glProgram = -1;
+		if (glProgram != -1)
+		{
+			gl.glDeleteProgram(glProgram);
+			glProgram = -1;
+		}
 
-		gl.glDeleteProgram(glComputeProgram);
-		glComputeProgram = -1;
+		if (glComputeProgram != -1)
+		{
+			gl.glDeleteProgram(glComputeProgram);
+			glComputeProgram = -1;
+		}
 
-		gl.glDeleteProgram(glSmallComputeProgram);
-		glSmallComputeProgram = -1;
+		if (glSmallComputeProgram != -1)
+		{
+			gl.glDeleteProgram(glSmallComputeProgram);
+			glSmallComputeProgram = -1;
+		}
 
-		gl.glDeleteProgram(glUnorderedComputeProgram);
-		glUnorderedComputeProgram = -1;
+		if (glUnorderedComputeProgram != -1)
+		{
+			gl.glDeleteProgram(glUnorderedComputeProgram);
+			glUnorderedComputeProgram = -1;
+		}
 
-		gl.glDeleteProgram(glUiProgram);
-		glUiProgram = -1;
+		if (glUiProgram != -1)
+		{
+			gl.glDeleteProgram(glUiProgram);
+			glUiProgram = -1;
+		}
 
-		gl.glDeleteProgram(glShadowProgram);
-		glShadowProgram = -1;
+		if (glShadowProgram != -1)
+		{
+			gl.glDeleteProgram(glShadowProgram);
+			glShadowProgram = -1;
+		}
 	}
 
 	private void recompileProgram()
@@ -991,14 +1009,23 @@ public class HdPlugin extends Plugin implements DrawCallbacks
 
 	private void shutdownVao()
 	{
-		glDeleteVertexArrays(gl, vaoHandle);
-		vaoHandle = -1;
+		if (vaoHandle != -1)
+		{
+			glDeleteVertexArrays(gl, vaoHandle);
+			vaoHandle = -1;
+		}
 
-		glDeleteBuffer(gl, vboUiHandle);
-		vboUiHandle = -1;
+		if (vboUiHandle != -1)
+		{
+			glDeleteBuffer(gl, vboUiHandle);
+			vboUiHandle = -1;
+		}
 
-		glDeleteVertexArrays(gl, vaoUiHandle);
-		vaoUiHandle = -1;
+		if (vaoUiHandle != -1)
+		{
+			glDeleteVertexArrays(gl, vaoUiHandle);
+			vaoUiHandle = -1;
+		}
 	}
 
 	private void initBuffers()
@@ -1070,9 +1097,17 @@ public class HdPlugin extends Plugin implements DrawCallbacks
 
 	private void shutdownInterfaceTexture()
 	{
-		glDeleteBuffer(gl, interfacePbo);
-		glDeleteTexture(gl, interfaceTexture);
-		interfaceTexture = -1;
+		if (interfacePbo != -1)
+		{
+			glDeleteBuffer(gl, interfacePbo);
+			interfacePbo = -1;
+		}
+
+		if (interfaceTexture != -1)
+		{
+			glDeleteTexture(gl, interfaceTexture);
+			interfaceTexture = -1;
+		}
 	}
 
 	private void initUniformBuffer()

--- a/src/main/java/rs117/hd/opengl/compute/OpenCLManager.java
+++ b/src/main/java/rs117/hd/opengl/compute/OpenCLManager.java
@@ -39,7 +39,6 @@ import jogamp.opengl.macosx.cgl.CGL;
 import jogamp.opengl.windows.wgl.WindowsWGLContext;
 import jogamp.opengl.x11.glx.X11GLXContext;
 import lombok.extern.slf4j.Slf4j;
-import net.runelite.client.plugins.gpu.template.Template;
 import net.runelite.client.util.OSType;
 import org.jocl.CL;
 import static org.jocl.CL.*;
@@ -56,6 +55,7 @@ import org.jocl.cl_mem;
 import org.jocl.cl_platform_id;
 import org.jocl.cl_program;
 import rs117.hd.HdPlugin;
+import rs117.hd.opengl.shader.Template;
 import rs117.hd.utils.buffer.GLBuffer;
 
 @Singleton


### PR DESCRIPTION
Avoid crashes during cleanup in the event of a crash during startup. This currently leads to having to restart the whole client whenever shader compilation fails.

Also removes an incorrect import depending on RuneLite's GPU plugin.