### PR TITLE
Update sky color whenever the skybox plugin config is changed

### DIFF
--- a/src/main/java/rs117/hd/HdPlugin.java
+++ b/src/main/java/rs117/hd/HdPlugin.java
@@ -101,6 +101,7 @@ import static rs117.hd.GLUtil.glGenTexture;
 import static rs117.hd.GLUtil.glGenVertexArrays;
 import static rs117.hd.GLUtil.glGetInteger;
 import rs117.hd.config.AntiAliasingMode;
+import rs117.hd.config.DefaultSkyColor;
 import rs117.hd.config.FogDepthMode;
 import rs117.hd.config.UIScalingMode;
 import rs117.hd.environments.EnvironmentManager;
@@ -2326,9 +2327,26 @@ public class HdPlugin extends Plugin implements DrawCallbacks
 		log.debug("-- generateUnderwaterTerrain: {}ms", timerGenerateUnderwaterTerrain);
 	}
 
+	private boolean skyboxColorChanged = false;
+
+	@Subscribe(priority = -1)
+	public void onBeforeRender(BeforeRender event) {
+		// Update sky color after the skybox plugin has had time to update the client's sky color
+		if (skyboxColorChanged) {
+			skyboxColorChanged = false;
+			environmentManager.updateSkyColor();
+		}
+	}
+
 	@Subscribe
 	public void onConfigChanged(ConfigChanged event)
 	{
+		if (event.getGroup().equals("skybox") && config.defaultSkyColor() == DefaultSkyColor.RUNELITE)
+		{
+			skyboxColorChanged = true;
+			return;
+		}
+
 		if (!event.getGroup().equals("hd"))
 		{
 			return;

--- a/src/main/java/rs117/hd/config/DefaultSkyColor.java
+++ b/src/main/java/rs117/hd/config/DefaultSkyColor.java
@@ -33,8 +33,8 @@ import rs117.hd.HDUtils;
 @RequiredArgsConstructor
 public enum DefaultSkyColor
 {
-	DEFAULT("RuneLite Skybox", -1, -1, -1),
-	BLUE("117HD (Blue)", 185, 214, 255),
+	DEFAULT("117HD (Blue)", 185, 214, 255),
+	RUNELITE("RuneLite Skybox", -1, -1, -1),
 	OSRS("Old School (Black)", 0, 0, 0),
 	HD2008("2008 HD (Tan)", 200, 192, 169);
 
@@ -53,7 +53,7 @@ public enum DefaultSkyColor
 		int r = this.r;
 		int g = this.g;
 		int b = this.b;
-		if (this == DEFAULT)
+		if (this == RUNELITE)
 		{
 			int sky = client.getSkyboxColor();
 			r = sky >> 16 & 0xFF;

--- a/src/main/java/rs117/hd/environments/EnvironmentManager.java
+++ b/src/main/java/rs117/hd/environments/EnvironmentManager.java
@@ -273,26 +273,7 @@ public class EnvironmentManager
 		startUnderwaterCausticsColor = currentUnderwaterCausticsColor;
 		startUnderwaterCausticsStrength = currentUnderwaterCausticsStrength;
 
-		// set target variables to ones from new environment
-		targetFogColor = newEnvironment.getFogColor();
-		targetWaterColor = targetFogColor;
-		if (!newEnvironment.isCustomFogColor())
-		{
-			if (hdPlugin.configWinterTheme)
-			{
-				targetFogColor = Environment.WINTER.getFogColor();
-				targetWaterColor = targetFogColor;
-			}
-			else
-			{
-				targetFogColor = config.defaultSkyColor().getRgb(client);
-			}
-		}
-
-		// If configured and the environment allows it override the skybox color to the default sky color.
-		if (config.overrideSky() && newEnvironment.isAllowSkyOverride()) {
-			targetFogColor = config.defaultSkyColor().getRgb(client);
-		}
+		updateSkyColor();
 
 		targetFogDepth = newEnvironment.getFogDepth();
 		if (hdPlugin.configWinterTheme)
@@ -383,6 +364,25 @@ public class EnvironmentManager
 		if (tileChange >= skipTransitionTiles)
 		{
 			transitionCompleteTime = startTime;
+		}
+	}
+
+	public void updateSkyColor()
+	{
+		Environment env = hdPlugin.configWinterTheme ? Environment.WINTER : currentEnvironment;
+		if (!env.isCustomAmbientColor() || env.isAllowSkyOverride() && config.overrideSky())
+		{
+			DefaultSkyColor sky = config.defaultSkyColor();
+			targetFogColor = sky.getRgb(client);
+			if (sky == DefaultSkyColor.OSRS)
+			{
+				sky = DefaultSkyColor.DEFAULT;
+			}
+			targetWaterColor = sky.getRgb(client);
+		}
+		else
+		{
+			targetFogColor = targetWaterColor = env.getFogColor();
 		}
 	}
 


### PR DESCRIPTION
Trigger a sky color update when the Skybox plugin's config changes, if the current sky is set to use RuneLite's skybox. This is done in `onBeforeRender` with a lower priority so it runs after the Skybox plugin updates its sky color. Maybe there's a better way to go about this, but I'm not sure.

Other changes:
- I've changed the default back to blue after it was changed to RuneLite's skybox in connection with #288, since it fits a lot better with HD than the Skybox plugin's default color. Ideally, this would be added to runelite/plugin-hub#2638 so we don't change the default away from blue in the live version.
  HD Blue:
  ![image](https://user-images.githubusercontent.com/831317/166727723-37429f16-8816-4f16-87d9-2ce23bfe6e1d.png)
  Skybox plugin's default:
  ![image](https://user-images.githubusercontent.com/831317/166727654-076351a6-c9d2-4118-9567-8d8b61e56e19.png)
- I've also changed the logic for applying water color slightly. Now it applies color also from the default sky, unless it's set to `OSRS` (which is all black), where it'll instead use HD's default blue sky.
  Here's how that looks with the tan sky option:
  ![image](https://user-images.githubusercontent.com/831317/166728052-935e48f5-d3d4-4ff6-9145-bb4f9763f914.png)
  And here's vanilla black:
  ![image](https://user-images.githubusercontent.com/831317/166729573-0f6666fb-c3d7-4647-9972-74013934e945.png)
