### PR TITLE
Add tile info overlay for development

### DIFF
--- a/src/main/java/rs117/hd/overlays/TileInfoOverlay.java
+++ b/src/main/java/rs117/hd/overlays/TileInfoOverlay.java
@@ -1,0 +1,232 @@
+package rs117.hd.overlays;
+
+import com.google.inject.Inject;
+import java.awt.BasicStroke;
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.FontMetrics;
+import java.awt.Graphics2D;
+import java.awt.Polygon;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.function.Function;
+import net.runelite.api.Client;
+import static net.runelite.api.Constants.MAX_Z;
+import static net.runelite.api.Constants.SCENE_SIZE;
+import net.runelite.api.Perspective;
+import net.runelite.api.Point;
+import net.runelite.api.Scene;
+import net.runelite.api.SceneTileModel;
+import net.runelite.api.SceneTilePaint;
+import net.runelite.api.Tile;
+import net.runelite.api.coords.LocalPoint;
+import net.runelite.client.ui.overlay.OverlayUtil;
+import org.apache.commons.lang3.tuple.Pair;
+import rs117.hd.data.materials.Material;
+import rs117.hd.data.materials.Overlay;
+import rs117.hd.data.materials.Underlay;
+import rs117.hd.utils.HDUtils;
+
+public class TileInfoOverlay extends net.runelite.client.ui.overlay.Overlay
+{
+	private final Client client;
+	private Point mousePos;
+
+	@Inject
+	public TileInfoOverlay(Client client)
+	{
+		this.client = client;
+	}
+
+	@Override
+	public Dimension render(Graphics2D g)
+	{
+		if (!client.isMenuOpen())
+		{
+			mousePos = client.getMouseCanvasPosition();
+		}
+
+		if (mousePos != null && mousePos.getX() == -1 && mousePos.getY() == -1)
+		{
+			return null;
+		}
+
+		g.setStroke(new BasicStroke(1, BasicStroke.CAP_BUTT, BasicStroke.JOIN_ROUND));
+
+		Scene scene = client.getScene();
+		byte[][][] overlayIds = scene.getOverlayIds();
+		byte[][][] underlayIds = scene.getUnderlayIds();
+		Tile[][][] tiles = scene.getTiles();
+		for (int x = 0; x < SCENE_SIZE; x++)
+		{
+			for (int y = 0; y < SCENE_SIZE; y++)
+			{
+				for (int plane = MAX_Z - 1; plane >= 0; plane--)
+				{
+					Tile tile = tiles[plane][x][y];
+					if (tile == null)
+					{
+						continue;
+					}
+
+					LocalPoint loc = tile.getLocalLocation();
+					Point tileCenter = Perspective.localToCanvas(client, loc, 0);
+					if (tileCenter == null)
+					{
+						continue;
+					}
+
+					Polygon poly = Perspective.getCanvasTilePoly(client, loc);
+					if (poly != null && poly.contains(mousePos.getX(), mousePos.getY()))
+					{
+						SceneTilePaint paint = tile.getSceneTilePaint();
+						SceneTileModel model = tile.getSceneTileModel();
+
+						if ((paint == null || paint.getNeColor() == 12345678) && model == null)
+						{
+							continue;
+						}
+
+						ArrayList<String> lines = new ArrayList<>();
+
+						int overlayId = overlayIds[plane][x][y];
+						Overlay overlay = Overlay.getOverlay(overlayId, tile, client);
+						lines.add(String.format("Overlay: %s (%d)", overlay.name(), overlayId));
+
+						int underlayId = underlayIds[plane][x][y];
+						Underlay underlay = Underlay.getUnderlay(underlayId, tile, client);
+						lines.add(String.format("Underlay: %s (%d)", underlay.name(), underlayId));
+
+						Color polyColor;
+						if (paint != null)
+						{
+							polyColor = Color.CYAN;
+							lines.add("Tile type: Paint");
+							lines.add("RGB: " + Arrays.toString(HDUtils.colorIntToRGB(paint.getRBG())));
+							Material material = Material.getTexture(paint.getTexture());
+							lines.add(String.format("Material: %s (%d)", material.name(), paint.getTexture()));
+						}
+						else
+						{
+							polyColor = Color.ORANGE;
+							lines.add("Tile type: Model");
+							lines.add(String.format("Face count: %d", model.getFaceX().length));
+							HashSet<String> uniqueMaterials = new HashSet<>();
+							int numChars = 0;
+							if (model.getTriangleTextureId() != null)
+							{
+								for (int texture : model.getTriangleTextureId())
+								{
+									String material = String.format("%s (%d)", Material.getTexture(texture).name(), texture);
+									boolean unique = uniqueMaterials.add(material);
+									if (unique)
+									{
+										numChars += material.length();
+									}
+								}
+							}
+
+							ArrayList<String> materials = new ArrayList<>(uniqueMaterials);
+							Collections.sort(materials);
+
+							if (materials.size() <= 1 || numChars < 26)
+							{
+								StringBuilder sb = new StringBuilder("Materials: { ");
+								if (materials.size() == 0)
+								{
+									sb.append("null");
+								}
+								else
+								{
+									String prefix = "";
+									for (String m : materials)
+									{
+										sb.append(prefix).append(m);
+										prefix = ", ";
+									}
+								}
+								sb.append(" }");
+								lines.add(sb.toString());
+							}
+							else
+							{
+								Iterator<String> iter = materials.iterator();
+								lines.add("Materials: { " + iter.next() + ",");
+								while (iter.hasNext())
+								{
+									lines.add("\t  " + iter.next() + (iter.hasNext() ? "," : " }"));
+								}
+							}
+						}
+
+						int padding = 4;
+						FontMetrics fm = g.getFontMetrics();
+						int lineHeight = fm.getHeight();
+						int totalHeight = lineHeight * lines.size();
+						int space = fm.charWidth(':');
+						int indent = fm.stringWidth("{ ");
+						int px = tileCenter.getX();
+						int py = tileCenter.getY();
+						int offsetY = -totalHeight - 20;
+
+						int leftWidth = 0;
+						int rightWidth = 0;
+
+						Function<String, Pair<String, String>> splitter = line ->
+						{
+							int i = line.indexOf(":");
+							String left = line;
+							String right = "";
+							if (i != -1)
+							{
+								left = line.substring(0, i);
+								right = line.substring(i + 1);
+							}
+							else if (left.startsWith("\t"))
+							{
+								right = left;
+								left = "";
+							}
+
+							return Pair.of(left, right);
+						};
+
+						for (String line : lines)
+						{
+							Pair<String, String> pair = splitter.apply(line);
+							leftWidth = Math.max(leftWidth, fm.stringWidth(pair.getLeft()));
+							rightWidth = Math.max(rightWidth, fm.stringWidth(pair.getRight()));
+						}
+
+						g.setColor(polyColor);
+						g.drawPolygon(poly);
+
+						g.setColor(new Color(0, 0, 0, 150));
+						int totalWidth = leftWidth + rightWidth + space + padding * 4;
+						g.fillRect(
+							px - totalWidth / 2, py + offsetY - padding,
+							totalWidth, totalHeight + padding * 3);
+						px -= (leftWidth + rightWidth + space) / 2 - leftWidth;
+
+						for (String line : lines)
+						{
+							Pair<String, String> pair = splitter.apply(line);
+							offsetY += lineHeight;
+							Point p = new Point(
+								px - fm.stringWidth(pair.getLeft()) + (pair.getRight().startsWith("\t") ? indent : 0),
+								py + offsetY);
+							OverlayUtil.renderTextLocation(g, p, line, Color.WHITE);
+						}
+
+						return null;
+					}
+				}
+			}
+		}
+
+		return null;
+	}
+}

--- a/src/main/java/rs117/hd/overlays/TileInfoOverlay.java
+++ b/src/main/java/rs117/hd/overlays/TileInfoOverlay.java
@@ -7,16 +7,20 @@ import java.awt.Dimension;
 import java.awt.FontMetrics;
 import java.awt.Graphics2D;
 import java.awt.Polygon;
+import java.awt.Rectangle;
+import java.awt.geom.Rectangle2D;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.function.Function;
+import javax.annotation.Nonnull;
 import net.runelite.api.Client;
 import static net.runelite.api.Constants.MAX_Z;
 import static net.runelite.api.Constants.SCENE_SIZE;
 import net.runelite.api.Perspective;
+import static net.runelite.api.Perspective.LOCAL_TILE_SIZE;
 import net.runelite.api.Point;
 import net.runelite.api.Scene;
 import net.runelite.api.SceneTileModel;
@@ -44,11 +48,7 @@ public class TileInfoOverlay extends net.runelite.client.ui.overlay.Overlay
 	@Override
 	public Dimension render(Graphics2D g)
 	{
-		if (!client.isMenuOpen())
-		{
-			mousePos = client.getMouseCanvasPosition();
-		}
-
+		mousePos = client.getMouseCanvasPosition();
 		if (mousePos != null && mousePos.getX() == -1 && mousePos.getY() == -1)
 		{
 			return null;
@@ -57,176 +57,313 @@ public class TileInfoOverlay extends net.runelite.client.ui.overlay.Overlay
 		g.setStroke(new BasicStroke(1, BasicStroke.CAP_BUTT, BasicStroke.JOIN_ROUND));
 
 		Scene scene = client.getScene();
-		byte[][][] overlayIds = scene.getOverlayIds();
-		byte[][][] underlayIds = scene.getUnderlayIds();
 		Tile[][][] tiles = scene.getTiles();
-		for (int x = 0; x < SCENE_SIZE; x++)
+		for (int plane = client.getPlane(); plane >= 0; plane--)
 		{
-			for (int y = 0; y < SCENE_SIZE; y++)
+			for (int isBridge = 1; isBridge >= 0; isBridge--)
 			{
-				for (int plane = MAX_Z - 1; plane >= 0; plane--)
+				for (int x = 0; x < SCENE_SIZE; x++)
 				{
-					Tile tile = tiles[plane][x][y];
-					if (tile == null)
+					for (int y = 0; y < SCENE_SIZE; y++)
 					{
-						continue;
-					}
-
-					LocalPoint loc = tile.getLocalLocation();
-					Point tileCenter = Perspective.localToCanvas(client, loc, 0);
-					if (tileCenter == null)
-					{
-						continue;
-					}
-
-					Polygon poly = Perspective.getCanvasTilePoly(client, loc);
-					if (poly != null && poly.contains(mousePos.getX(), mousePos.getY()))
-					{
-						SceneTilePaint paint = tile.getSceneTilePaint();
-						SceneTileModel model = tile.getSceneTileModel();
-
-						if ((paint == null || paint.getNeColor() == 12345678) && model == null)
+						Tile tile = tiles[plane][x][y];
+						boolean shouldDraw = tile != null && (isBridge == 0 || tile.getBridge() != null);
+						if (shouldDraw && drawTileInfo(g, tile))
 						{
-							continue;
+							return null;
 						}
-
-						ArrayList<String> lines = new ArrayList<>();
-
-						int overlayId = overlayIds[plane][x][y];
-						Overlay overlay = Overlay.getOverlay(overlayId, tile, client);
-						lines.add(String.format("Overlay: %s (%d)", overlay.name(), overlayId));
-
-						int underlayId = underlayIds[plane][x][y];
-						Underlay underlay = Underlay.getUnderlay(underlayId, tile, client);
-						lines.add(String.format("Underlay: %s (%d)", underlay.name(), underlayId));
-
-						Color polyColor;
-						if (paint != null)
-						{
-							polyColor = Color.CYAN;
-							lines.add("Tile type: Paint");
-							lines.add("RGB: " + Arrays.toString(HDUtils.colorIntToRGB(paint.getRBG())));
-							Material material = Material.getTexture(paint.getTexture());
-							lines.add(String.format("Material: %s (%d)", material.name(), paint.getTexture()));
-						}
-						else
-						{
-							polyColor = Color.ORANGE;
-							lines.add("Tile type: Model");
-							lines.add(String.format("Face count: %d", model.getFaceX().length));
-							HashSet<String> uniqueMaterials = new HashSet<>();
-							int numChars = 0;
-							if (model.getTriangleTextureId() != null)
-							{
-								for (int texture : model.getTriangleTextureId())
-								{
-									String material = String.format("%s (%d)", Material.getTexture(texture).name(), texture);
-									boolean unique = uniqueMaterials.add(material);
-									if (unique)
-									{
-										numChars += material.length();
-									}
-								}
-							}
-
-							ArrayList<String> materials = new ArrayList<>(uniqueMaterials);
-							Collections.sort(materials);
-
-							if (materials.size() <= 1 || numChars < 26)
-							{
-								StringBuilder sb = new StringBuilder("Materials: { ");
-								if (materials.size() == 0)
-								{
-									sb.append("null");
-								}
-								else
-								{
-									String prefix = "";
-									for (String m : materials)
-									{
-										sb.append(prefix).append(m);
-										prefix = ", ";
-									}
-								}
-								sb.append(" }");
-								lines.add(sb.toString());
-							}
-							else
-							{
-								Iterator<String> iter = materials.iterator();
-								lines.add("Materials: { " + iter.next() + ",");
-								while (iter.hasNext())
-								{
-									lines.add("\t  " + iter.next() + (iter.hasNext() ? "," : " }"));
-								}
-							}
-						}
-
-						int padding = 4;
-						FontMetrics fm = g.getFontMetrics();
-						int lineHeight = fm.getHeight();
-						int totalHeight = lineHeight * lines.size();
-						int space = fm.charWidth(':');
-						int indent = fm.stringWidth("{ ");
-						int px = tileCenter.getX();
-						int py = tileCenter.getY();
-						int offsetY = -totalHeight - 20;
-
-						int leftWidth = 0;
-						int rightWidth = 0;
-
-						Function<String, Pair<String, String>> splitter = line ->
-						{
-							int i = line.indexOf(":");
-							String left = line;
-							String right = "";
-							if (i != -1)
-							{
-								left = line.substring(0, i);
-								right = line.substring(i + 1);
-							}
-							else if (left.startsWith("\t"))
-							{
-								right = left;
-								left = "";
-							}
-
-							return Pair.of(left, right);
-						};
-
-						for (String line : lines)
-						{
-							Pair<String, String> pair = splitter.apply(line);
-							leftWidth = Math.max(leftWidth, fm.stringWidth(pair.getLeft()));
-							rightWidth = Math.max(rightWidth, fm.stringWidth(pair.getRight()));
-						}
-
-						g.setColor(polyColor);
-						g.drawPolygon(poly);
-
-						g.setColor(new Color(0, 0, 0, 150));
-						int totalWidth = leftWidth + rightWidth + space + padding * 4;
-						g.fillRect(
-							px - totalWidth / 2, py + offsetY - padding,
-							totalWidth, totalHeight + padding * 3);
-						px -= (leftWidth + rightWidth + space) / 2 - leftWidth;
-
-						for (String line : lines)
-						{
-							Pair<String, String> pair = splitter.apply(line);
-							offsetY += lineHeight;
-							Point p = new Point(
-								px - fm.stringWidth(pair.getLeft()) + (pair.getRight().startsWith("\t") ? indent : 0),
-								py + offsetY);
-							OverlayUtil.renderTextLocation(g, p, line, Color.WHITE);
-						}
-
-						return null;
 					}
 				}
 			}
 		}
 
 		return null;
+	}
+
+	private boolean drawTileInfo(Graphics2D g, Tile tile)
+	{
+		boolean infoDrawn = false;
+
+		if (tile != null)
+		{
+			Rectangle rect = null;
+			Polygon poly;
+
+			Tile bridge = tile.getBridge();
+			if (bridge != null)
+			{
+				poly = getCanvasTilePoly(client, bridge);
+				if (poly != null && poly.contains(mousePos.getX(), mousePos.getY()))
+				{
+					rect = drawTileInfo(g, bridge, poly, rect);
+					if (rect != null)
+					{
+						infoDrawn = true;
+					}
+				}
+			}
+
+			poly = getCanvasTilePoly(client, tile);
+			if (poly != null && poly.contains(mousePos.getX(), mousePos.getY()))
+			{
+				rect = drawTileInfo(g, tile, poly, rect);
+				if (rect != null)
+				{
+					infoDrawn = true;
+				}
+			}
+		}
+
+		return infoDrawn;
+	}
+
+	private Rectangle drawTileInfo(Graphics2D g, Tile tile, Polygon poly, Rectangle dodgeRect)
+	{
+		SceneTilePaint paint = tile.getSceneTilePaint();
+		SceneTileModel model = tile.getSceneTileModel();
+
+		if ((paint == null || (paint.getNeColor() == 12345678 && tile.getBridge() == null)) && model == null)
+		{
+			return null;
+		}
+
+		Rectangle2D polyBounds = poly.getBounds2D();
+		Point tileCenter = new Point((int) polyBounds.getCenterX(), (int) polyBounds.getCenterY());
+
+		ArrayList<String> lines = new ArrayList<>();
+
+		if (tile.getBridge() != null)
+		{
+			lines.add("Bridge");
+		}
+
+		int x = tile.getSceneLocation().getX();
+		int y = tile.getSceneLocation().getY();
+		int plane = tile.getRenderLevel();
+
+		Scene scene = client.getScene();
+		int overlayId = scene.getOverlayIds()[plane][x][y];
+		Overlay overlay = Overlay.getOverlay(overlayId, tile, client);
+		lines.add(String.format("Overlay: %s (%d)", overlay.name(), overlayId));
+
+		int underlayId = scene.getOverlayIds()[plane][x][y];
+		Underlay underlay = Underlay.getUnderlay(underlayId, tile, client);
+		lines.add(String.format("Underlay: %s (%d)", underlay.name(), underlayId));
+
+		Color polyColor;
+		if (paint != null)
+		{
+			polyColor = Color.CYAN;
+			lines.add("Tile type: Paint");
+			lines.add("RGB: " + (paint.getNeColor() == 12345678 ? "Hidden" :
+				Arrays.toString(HDUtils.colorIntToRGB(paint.getRBG()))));
+			Material material = Material.getTexture(paint.getTexture());
+			lines.add(String.format("Material: %s (%d)", material.name(), paint.getTexture()));
+		}
+		else
+		{
+			polyColor = Color.ORANGE;
+			lines.add("Tile type: Model");
+			lines.add(String.format("Face count: %d", model.getFaceX().length));
+			HashSet<String> uniqueMaterials = new HashSet<>();
+			int numChars = 0;
+			if (model.getTriangleTextureId() != null)
+			{
+				for (int texture : model.getTriangleTextureId())
+				{
+					String material = String.format("%s (%d)", Material.getTexture(texture).name(), texture);
+					boolean unique = uniqueMaterials.add(material);
+					if (unique)
+					{
+						numChars += material.length();
+					}
+				}
+			}
+
+			ArrayList<String> materials = new ArrayList<>(uniqueMaterials);
+			Collections.sort(materials);
+
+			if (materials.size() <= 1 || numChars < 26)
+			{
+				StringBuilder sb = new StringBuilder("Materials: { ");
+				if (materials.size() == 0)
+				{
+					sb.append("null");
+				}
+				else
+				{
+					String prefix = "";
+					for (String m : materials)
+					{
+						sb.append(prefix).append(m);
+						prefix = ", ";
+					}
+				}
+				sb.append(" }");
+				lines.add(sb.toString());
+			}
+			else
+			{
+				Iterator<String> iter = materials.iterator();
+				lines.add("Materials: { " + iter.next() + ",");
+				while (iter.hasNext())
+				{
+					lines.add("\t  " + iter.next() + (iter.hasNext() ? "," : " }"));
+				}
+			}
+		}
+
+		int padding = 4;
+		int xPadding = padding * 2;
+		int yPadding = padding;
+		FontMetrics fm = g.getFontMetrics();
+		int lineHeight = fm.getHeight();
+		int totalHeight = lineHeight * lines.size() + yPadding * 3;
+		int space = fm.charWidth(':');
+		int indent = fm.stringWidth("{ ");
+
+		int leftWidth = 0;
+		int rightWidth = 0;
+
+		Function<String, Pair<String, String>> splitter = line ->
+		{
+			int i = line.indexOf(":");
+			String left = line;
+			String right = "";
+			if (i != -1)
+			{
+				left = line.substring(0, i);
+				right = line.substring(i + 1);
+			}
+			else if (left.startsWith("\t"))
+			{
+				right = left;
+				left = "";
+			}
+
+			return Pair.of(left, right);
+		};
+
+		for (String line : lines)
+		{
+			Pair<String, String> pair = splitter.apply(line);
+			if (pair.getRight().length() == 0)
+			{
+				int halfWidth = fm.stringWidth(pair.getLeft()) / 2;
+				leftWidth = Math.max(leftWidth, halfWidth);
+				rightWidth = Math.max(rightWidth, halfWidth);
+			}
+			else
+			{
+				leftWidth = Math.max(leftWidth, fm.stringWidth(pair.getLeft()));
+				rightWidth = Math.max(rightWidth, fm.stringWidth(pair.getRight()));
+			}
+		}
+
+		int totalWidth = leftWidth + rightWidth + space + xPadding * 2;
+		Rectangle rect = new Rectangle(
+			tileCenter.getX() - totalWidth / 2,
+			tileCenter.getY() - totalHeight - yPadding, totalWidth, totalHeight);
+		if (dodgeRect != null && dodgeRect.intersects(rect))
+		{
+			// Avoid overlapping with other tile info
+			rect.y = dodgeRect.y - rect.height - yPadding;
+		}
+
+		if (tile.getBridge() != null)
+		{
+			polyColor = Color.MAGENTA;
+		}
+		g.setColor(polyColor);
+		g.drawPolygon(poly);
+
+		g.setColor(new Color(0, 0, 0, 150));
+		g.fillRect(rect.x, rect.y, rect.width, rect.height);
+
+		int offsetY = 0;
+		for (String line : lines)
+		{
+			Pair<String, String> pair = splitter.apply(line);
+			offsetY += lineHeight;
+			Point p;
+			if (pair.getRight().length() == 0)
+			{
+				// centered
+				p = new Point(
+					rect.x + rect.width / 2 - fm.stringWidth(pair.getLeft()) / 2,
+					rect.y + yPadding + offsetY);
+			}
+			else
+			{
+				// left & right
+				p = new Point(
+					rect.x + xPadding + leftWidth - fm.stringWidth(pair.getLeft()) + (pair.getRight().startsWith("\t") ? indent : 0),
+					rect.y + yPadding + offsetY);
+			}
+			OverlayUtil.renderTextLocation(g, p, line, Color.WHITE);
+		}
+
+		return rect;
+	}
+
+	/**
+	 * Returns a polygon representing a tile.
+	 *
+	 * @param client the game client
+	 * @param tile the tile
+	 * @return a polygon representing the tile
+	 */
+	public static Polygon getCanvasTilePoly(@Nonnull Client client, Tile tile)
+	{
+		LocalPoint localLocation = tile.getLocalLocation();
+		int plane = tile.getRenderLevel();
+		if (!localLocation.isInScene())
+		{
+			return null;
+		}
+
+		final int swX = localLocation.getX() - LOCAL_TILE_SIZE / 2;
+		final int swY = localLocation.getY() - LOCAL_TILE_SIZE / 2;
+
+		final int neX = localLocation.getX() + LOCAL_TILE_SIZE / 2;
+		final int neY = localLocation.getY() + LOCAL_TILE_SIZE / 2;
+
+		final int swHeight = getHeight(client, swX, swY, plane);
+		final int nwHeight = getHeight(client, neX, swY, plane);
+		final int neHeight = getHeight(client, neX, neY, plane);
+		final int seHeight = getHeight(client, swX, neY, plane);
+
+		Point p1 = Perspective.localToCanvas(client, swX, swY, swHeight);
+		Point p2 = Perspective.localToCanvas(client, neX, swY, nwHeight);
+		Point p3 = Perspective.localToCanvas(client, neX, neY, neHeight);
+		Point p4 = Perspective.localToCanvas(client, swX, neY, seHeight);
+
+		if (p1 == null || p2 == null || p3 == null || p4 == null)
+		{
+			return null;
+		}
+
+		Polygon poly = new Polygon();
+		poly.addPoint(p1.getX(), p1.getY());
+		poly.addPoint(p2.getX(), p2.getY());
+		poly.addPoint(p3.getX(), p3.getY());
+		poly.addPoint(p4.getX(), p4.getY());
+
+		return poly;
+	}
+
+	private static int getHeight(@Nonnull Client client, int localX, int localY, int plane) {
+		int sceneX = localX >> 7;
+		int sceneY = localY >> 7;
+		if (sceneX >= 0 && sceneY >= 0 && sceneX < 104 && sceneY < 104) {
+			int[][][] tileHeights = client.getTileHeights();
+			int x = localX & 127;
+			int y = localY & 127;
+			int var8 = x * tileHeights[plane][sceneX + 1][sceneY] + (128 - x) * tileHeights[plane][sceneX][sceneY] >> 7;
+			int var9 = tileHeights[plane][sceneX][sceneY + 1] * (128 - x) + x * tileHeights[plane][sceneX + 1][sceneY + 1] >> 7;
+			return (128 - y) * var8 + y * var9 >> 7;
+		} else {
+			return 0;
+		}
 	}
 }

--- a/src/main/java/rs117/hd/scene/lighting/LightManager.java
+++ b/src/main/java/rs117/hd/scene/lighting/LightManager.java
@@ -71,7 +71,7 @@ import rs117.hd.utils.FileWatcher;
 @Slf4j
 public class LightManager
 {
-	public static String LIGHTS_CONFIG_ENV = "RLHD_LIGHTS_PATH";
+	public static String ENV_LIGHTS_CONFIG = "RLHD_LIGHTS_PATH";
 
 	@Inject
 	private ConfigManager configManager;
@@ -119,7 +119,7 @@ public class LightManager
 
 		entityHiderConfig = configManager.getConfig(EntityHiderConfig.class);
 
-		Path lightsConfigPath = Env.getPath(LIGHTS_CONFIG_ENV);
+		Path lightsConfigPath = Env.getPath(ENV_LIGHTS_CONFIG);
 		if (lightsConfigPath == null)
 		{
 			reloadLightConfiguration();
@@ -181,7 +181,7 @@ public class LightManager
 		if (hotswapScheduled)
 		{
 			hotswapScheduled = false;
-			Path lightsConfigPath = Env.getPath(LIGHTS_CONFIG_ENV);
+			Path lightsConfigPath = Env.getPath(ENV_LIGHTS_CONFIG);
 			if (lightsConfigPath != null && lightsConfigPath.toFile().exists())
 			{
 				reloadLightConfiguration(lightsConfigPath.toFile());

--- a/src/main/java/rs117/hd/scene/lighting/LightManager.java
+++ b/src/main/java/rs117/hd/scene/lighting/LightManager.java
@@ -116,7 +116,6 @@ public class LightManager
 
 	public void startUp()
 	{
-
 		entityHiderConfig = configManager.getConfig(EntityHiderConfig.class);
 
 		Path lightsConfigPath = Env.getPath(ENV_LIGHTS_CONFIG);

--- a/src/main/java/rs117/hd/utils/DeveloperTools.java
+++ b/src/main/java/rs117/hd/utils/DeveloperTools.java
@@ -1,0 +1,130 @@
+package rs117.hd.utils;
+
+import java.awt.event.InputEvent;
+import java.awt.event.KeyEvent;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.nio.file.Path;
+import javax.inject.Inject;
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.client.config.Keybind;
+import net.runelite.client.input.KeyListener;
+import net.runelite.client.input.KeyManager;
+import net.runelite.client.ui.overlay.OverlayManager;
+import rs117.hd.HdPlugin;
+import rs117.hd.HdPluginConfig;
+import rs117.hd.opengl.shader.Template;
+import rs117.hd.overlays.TileInfoOverlay;
+
+@Slf4j
+public class DeveloperTools implements KeyListener
+{
+	public static final String ENV_SHADER_PATH = "RLHD_SHADER_PATH";
+
+	// This could be part of the config if we had developer mode config sections
+	private static final Keybind KEY_TOGGLE_TILE_INFO = new Keybind(KeyEvent.VK_F3, InputEvent.CTRL_DOWN_MASK);
+
+	@Inject
+	private HdPluginConfig config;
+
+	@Inject
+	private HdPlugin plugin;
+
+	@Inject
+	private KeyManager keyManager;
+
+	@Inject
+	private OverlayManager overlayManager;
+
+	@Inject
+	private TileInfoOverlay tileInfoOverlay;
+
+	private Path shaderPath;
+	private FileWatcher shaderSourceWatcher;
+	private boolean tileInfoOverlayEnabled = false;
+
+	public void activate() {
+		keyManager.registerKeyListener(this);
+		if (tileInfoOverlayEnabled)
+		{
+			overlayManager.add(tileInfoOverlay);
+		}
+
+		shaderPath = Env.getPath(ENV_SHADER_PATH);
+		if (shaderPath != null)
+		{
+			try
+			{
+				shaderSourceWatcher = new FileWatcher()
+					.watchPath(shaderPath)
+					.addChangeHandler(path ->
+					{
+						if (path.getFileName().toString().endsWith(".glsl"))
+						{
+							log.info("Reloading shaders...");
+							plugin.recompilePrograms();
+						}
+					});
+			}
+			catch (IOException ex)
+			{
+				throw new RuntimeException(ex);
+			}
+		}
+	}
+
+	public void deactivate() {
+		if (shaderSourceWatcher != null)
+		{
+			shaderSourceWatcher.close();
+			shaderSourceWatcher = null;
+		}
+
+		keyManager.unregisterKeyListener(this);
+		overlayManager.remove(tileInfoOverlay);
+	}
+
+	public String shaderResolver(String path) {
+		Path fullPath = shaderPath.resolve(path);
+		try
+		{
+			log.debug("Loading shader from file: {}", fullPath);
+			return Template.inputStreamToString(new FileInputStream(fullPath.toFile()));
+		}
+		catch (FileNotFoundException ex)
+		{
+			throw new RuntimeException("Failed to load shader from file: " + fullPath, ex);
+		}
+	}
+
+	@Override
+	public void keyPressed(KeyEvent event)
+	{
+		if (KEY_TOGGLE_TILE_INFO.matches(event))
+		{
+			event.consume();
+			tileInfoOverlayEnabled = !tileInfoOverlayEnabled;
+			if (tileInfoOverlayEnabled)
+			{
+				overlayManager.add(tileInfoOverlay);
+			}
+			else
+			{
+				overlayManager.remove(tileInfoOverlay);
+			}
+		}
+	}
+
+	@Override
+	public void keyReleased(KeyEvent event)
+	{
+
+	}
+
+	@Override
+	public void keyTyped(KeyEvent event)
+	{
+
+	}
+}

--- a/src/main/java/rs117/hd/utils/HDUtils.java
+++ b/src/main/java/rs117/hd/utils/HDUtils.java
@@ -164,7 +164,7 @@ public class HDUtils
 		return (colorHSL[0] << 3 | colorHSL[1]) << 7 | colorHSL[2];
 	}
 
-	static int[] colorIntToRGB(int colorInt)
+	public static int[] colorIntToRGB(int colorInt)
 	{
 		int[] outHSL = new int[3];
 		outHSL[0] = colorInt >> 10 & 0x3F;

--- a/src/test/java/rs117/hd/HdPluginTest.java
+++ b/src/test/java/rs117/hd/HdPluginTest.java
@@ -2,23 +2,24 @@ package rs117.hd;
 
 import net.runelite.client.RuneLite;
 import net.runelite.client.externalplugins.ExternalPluginManager;
-import static rs117.hd.HdPlugin.SHADER_PATH;
+import static rs117.hd.HdPlugin.ENV_SHADER_PATH;
 import rs117.hd.scene.lighting.LightManager;
-import static rs117.hd.scene.lighting.LightManager.LIGHTS_CONFIG_ENV;
+import static rs117.hd.scene.lighting.LightManager.ENV_LIGHTS_CONFIG;
 import rs117.hd.utils.Env;
 import rs117.hd.utils.FileWatcher;
 
+@SuppressWarnings("unchecked")
 public class HdPluginTest
 {
 	public static void main(String[] args) throws Exception
 	{
-		if (Env.missing(LIGHTS_CONFIG_ENV))
+		if (Env.missing(ENV_LIGHTS_CONFIG))
 		{
-			Env.set(LIGHTS_CONFIG_ENV, FileWatcher.getResourcePath(LightManager.class).resolve("lights.json"));
+			Env.set(ENV_LIGHTS_CONFIG, FileWatcher.getResourcePath(LightManager.class).resolve("lights.json"));
 		}
-		if (Env.missing(SHADER_PATH))
+		if (Env.missing(ENV_SHADER_PATH))
 		{
-			Env.set(SHADER_PATH, FileWatcher.getResourcePath(HdPlugin.class));
+			Env.set(ENV_SHADER_PATH, FileWatcher.getResourcePath(HdPlugin.class));
 		}
 
 		ExternalPluginManager.loadBuiltin(HdPlugin.class);

--- a/src/test/java/rs117/hd/HdPluginTest.java
+++ b/src/test/java/rs117/hd/HdPluginTest.java
@@ -2,9 +2,9 @@ package rs117.hd;
 
 import net.runelite.client.RuneLite;
 import net.runelite.client.externalplugins.ExternalPluginManager;
-import static rs117.hd.HdPlugin.ENV_SHADER_PATH;
 import rs117.hd.scene.lighting.LightManager;
 import static rs117.hd.scene.lighting.LightManager.ENV_LIGHTS_CONFIG;
+import static rs117.hd.utils.DeveloperTools.ENV_SHADER_PATH;
 import rs117.hd.utils.Env;
 import rs117.hd.utils.FileWatcher;
 


### PR DESCRIPTION
Adds the following overlay to help with modifying tile overlays, underlays and materials. Currently it's toggled by the hard-coded keybind Ctrl F3, and it only works while in developer mode.

![image](https://user-images.githubusercontent.com/831317/167047778-84610f5b-a4ad-453c-872d-6042061aad29.png)

![image](https://user-images.githubusercontent.com/831317/167047870-70bee734-4091-49bd-991b-594926e2dda1.png)

![image](https://user-images.githubusercontent.com/831317/167047876-161ad322-a4f6-4c89-be87-17a08ece7410.png)

This also restricts shader hot-swapping to developer mode.