### PR TITLE
Add missing Desert Treasure pyramid tile overlay

### DIFF
--- a/src/main/java/rs117/hd/data/materials/Overlay.java
+++ b/src/main/java/rs117/hd/data/materials/Overlay.java
@@ -252,6 +252,7 @@ public enum Overlay
 	OVERLAY_N84(-84, GroundMaterial.DIRT),
 	OVERLAY_N83(-83, GroundMaterial.DIRT),
 	OVERLAY_N82(-82, GroundMaterial.TILE_DARK),
+	OVERLAY_N49(-49, GroundMaterial.SAND_BRICK),
 	OVERLAY_2(2, GroundMaterial.GRAVEL),
 	OVERLAY_3(3, GroundMaterial.GRAVEL),
 	OVERLAY_4(4, GroundMaterial.GRAVEL),


### PR DESCRIPTION
Missing tile overlay:
![image](https://user-images.githubusercontent.com/831317/167151249-3cdb72f8-d39e-474b-9ced-249df3fa3f3d.png)

After this patch:
![image](https://user-images.githubusercontent.com/831317/167151288-4228070a-9fd0-4130-9c3e-c035186357c1.png)

Vanilla for reference:
![image](https://user-images.githubusercontent.com/831317/167151311-a372ae07-67d1-4480-a73d-44d4aa819c62.png)
