### PR TITLE
Fix misplaced water tiles in Temple of the Eye

### DIFF
--- a/src/main/java/rs117/hd/data/materials/Overlay.java
+++ b/src/main/java/rs117/hd/data/materials/Overlay.java
@@ -194,6 +194,9 @@ public enum Overlay
 	// Kebos Lowlands
 	LIZARDMAN_TEMPLE_WATER(-100, Area.LIZARDMAN_TEMPLE, WaterType.SWAMP_WATER_FLAT),
 
+	// Temple of the Eye
+	TEMPLE_OF_THE_EYE_INCORRECT_WATER(-100, Area.TEMPLE_OF_THE_EYE, GroundMaterial.DIRT),
+
 	// God Wars Dungeon (GWD)
 	GWD_WATER(104, Area.GOD_WARS_DUNGEON, WaterType.ICE_FLAT),
 


### PR DESCRIPTION
This is most noticeable in low detail mode.

Before:
![image](https://user-images.githubusercontent.com/831317/167153859-32d31d27-3ae5-4414-af75-f4662b9e8713.png)

After:
![image](https://user-images.githubusercontent.com/831317/167153653-3656b0f7-7da5-476b-961d-0844ce227271.png)