### PR TITLE
Fix incorrect instant transitions between environments

### DIFF
--- a/src/main/java/rs117/hd/scene/EnvironmentManager.java
+++ b/src/main/java/rs117/hd/scene/EnvironmentManager.java
@@ -63,7 +63,8 @@ public class EnvironmentManager
 	// transition time
 	private final int transitionDuration = 3000;
 	// distance in tiles to skip transition (e.g. entering cave, teleporting)
-	private final int skipTransitionTiles = 20;
+	// walking across a loading line causes a movement of 40-41 tiles
+	private final int skipTransitionTiles = 41;
 
 	// last environment change time
 	private long startTime = 0;


### PR DESCRIPTION
This should fix #199.

The issue seems to be that the environment instantly transitions (when it shouldn't) from `OVERWORLD` to `WILDERNESS_LOW` when loading under certain conditions, then a single frame is rendered before the environment again transitions instantly back to `OVERWORLD`. The issue with these instant transitions is that the ambient color (among other things) changes completely to the new environment only for that single frame.

The intent seems to have been to only cause new environments to apply instantly whenever the player is teleported to a new area, not when simply walking into a loading line. Because [`camTarget`](https://github.com/aHooder/RLHD/blob/b7c70412b82541c68d608ba5c85d21cc6e25f783/src/main/java/rs117/hd/scene/EnvironmentManager.java#L360-L370) is stored in local scene coordinates, the coordinates are shifted by 40 tiles when the origin is reset for the newly loaded scene, thus incorrectly triggering an instant change as if the player was just teleported. If the player is running through the loading line from an odd numbered tile, the new `camTarget` can also be 41 tiles away from the previous, hence the change to 41 instead of 40.