### PR TITLE
Fix switching between GPU plugins

### DIFF
--- a/src/main/java/rs117/hd/scene/SceneUploader.java
+++ b/src/main/java/rs117/hd/scene/SceneUploader.java
@@ -26,6 +26,7 @@
 package rs117.hd.scene;
 
 import com.google.common.base.Stopwatch;
+import java.util.Random;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import lombok.extern.slf4j.Slf4j;
@@ -73,7 +74,7 @@ class SceneUploader
 	@Inject
 	private ModelPusher modelPusher;
 
-	public int sceneId = (int) (System.currentTimeMillis() / 1000L);
+	public int sceneId = new Random().nextInt();
 	private int offset;
 	private int uvoffset;
 


### PR DESCRIPTION
Since the SceneUploader code is largely the same between different GPU plugins, there can be scene ID collisions if the plugins are initialized around the same time, then switched off and on a small number of times. This makes such collisions a whole lot less likely.