### PR TITLE
Fix GOTR Entrance

### DIFF
--- a/src/main/java/rs117/hd/data/environments/Area.java
+++ b/src/main/java/rs117/hd/data/environments/Area.java
@@ -731,6 +731,7 @@ public enum Area
 
 	// Guardians of the Rift
 	TEMPLE_OF_THE_EYE(3550, 9525, 3660, 9450),
+	TEMPLE_OF_THE_EYE_ENTRANCE_FIX(3613,9471,3617,9481),
 
 	// Death's office
 	DEATHS_OFFICE(3166, 5734, 3185, 4288),

--- a/src/main/java/rs117/hd/data/materials/Overlay.java
+++ b/src/main/java/rs117/hd/data/materials/Overlay.java
@@ -238,6 +238,10 @@ public enum Overlay
 	// Random events
 	PRISON_PETE_TILE_1(2, Area.RANDOM_EVENT_PRISON_PETE, GroundMaterial.MARBLE_1, new Properties().setBlended(false)),
 	PRISON_PETE_TILE_2(-125, Area.RANDOM_EVENT_PRISON_PETE, GroundMaterial.MARBLE_2, new Properties().setBlended(false)),
+	
+	// GOTR Entrance fix
+	TEMPLE_OF_THE_EYE_ENTRANCE(0, Area.TEMPLE_OF_THE_EYE_ENTRANCE_FIX, GroundMaterial.DIRT, new Properties().setShiftLightness(-10).setBlended(false)),
+	TEMPLE_OF_THE_EYE_ENTRANCE_2(-53, Area.TEMPLE_OF_THE_EYE_ENTRANCE_FIX, GroundMaterial.DIRT, new Properties().setShiftLightness(-10).setBlended(false)),
 
 
 


### PR DESCRIPTION
Tile blending was broken with the fancy pattern in front of the GOTR entrance/exit portal. I had no idea how to fix this before but turns out it's relatively simple and there is precedence elsewhere for loads of similar fixes.

Without ground blending:
![image](https://user-images.githubusercontent.com/73786759/168489745-6afd4be3-fa0b-4e04-88d3-6c6665c885e6.png)

With ground blending before fix:
![image](https://user-images.githubusercontent.com/73786759/168489649-d58dbcd3-d81f-4c54-a226-492a8244db36.png)

With ground blending after fix:
![image](https://user-images.githubusercontent.com/73786759/168489656-cfc1f3c3-5c18-4686-9c3b-22192b979577.png)

