### PR TITLE
Added the lit Braziers in Wintertodt as a light source

### DIFF
--- a/src/main/resources/rs117/hd/scene/lighting/lights.json
+++ b/src/main/resources/rs117/hd/scene/lighting/lights.json
@@ -29332,8 +29332,8 @@
     "description": "WINTERTODT_LIT_BRAZIER",
     "height": 300,
     "alignment": "CENTER",
-    "radius": 450,
-    "strength": 25,
+    "radius": 600,
+    "strength": 15,
     "color": [
         165,
         255,
@@ -29341,7 +29341,7 @@
     ],
     "type": "FLICKER",
     "duration": 0,
-    "range": 20,
+    "range": 15,
     "objectIds": [
         "BURNING_BRAZIER_29314",
         "BURNING_BRAZIER_31926"

--- a/src/main/resources/rs117/hd/scene/lighting/lights.json
+++ b/src/main/resources/rs117/hd/scene/lighting/lights.json
@@ -22566,24 +22566,6 @@
     ]
   },
   {
-    "description": "WINTERTODT_DOOR",
-    "height": 500,
-    "alignment": "SOUTH",
-    "radius": 1500,
-    "strength": 15,
-    "color": [
-      165,
-      255,
-      56
-    ],
-    "type": "STATIC",
-    "duration": 0,
-    "range": 0,
-    "objectIds": [
-      "DOORS_OF_DINH"
-    ]
-  },
-  {
     "description": "PURPLE_FLAME",
     "height": 250,
     "alignment": "CENTER",
@@ -29345,5 +29327,42 @@
     "duration": 7000.0,
     "range": 10.0,
     "fadeInDuration": 0
+  },
+  {
+    "description": "WINTERTODT_LIT_BRAZIER",
+    "height": 300,
+    "alignment": "CENTER",
+    "radius": 450,
+    "strength": 25,
+    "color": [
+        165,
+        255,
+        56
+    ],
+    "type": "FLICKER",
+    "duration": 0,
+    "range": 20,
+    "objectIds": [
+        "BURNING_BRAZIER_29314",
+        "BURNING_BRAZIER_31926"
+    ]
+  },
+  {
+    "description": "WINTERTODT_DOOR",
+    "height": 500,
+    "alignment": "SOUTH",
+    "radius": 1500,
+    "strength": 15,
+    "color": [
+        165,
+        255,
+        56
+    ],
+    "type": "STATIC",
+    "duration": 0,
+    "range": 0,
+    "objectIds": [
+        "DOORS_OF_DINH"
+    ]
   }
 ]


### PR DESCRIPTION
Working code that implements the feature I proposed in https://github.com/RS117/RLHD/issues/308#issue-1244055520!

# With/Without
![ShareX_Q9z4BKFWtt](https://user-images.githubusercontent.com/54869170/169673097-3f683e31-ea77-4fed-9ad6-208442ed0a6f.gif)

# "Flicker" effect
![ShareX_uqqemraSTp](https://user-images.githubusercontent.com/54869170/169673100-0c7746ad-1f7e-4109-bca7-1c92a6f185fd.gif)

Added the Lit Brazier to lights.json
```JSON
  {
    "description": "WINTERTODT_LIT_BRAZIER",
    "height": 300,
    "alignment": "CENTER",
    "radius": 600,
    "strength": 15,
    "color": [
        165,
        255,
        56
    ],
    "type": "FLICKER",
    "duration": 0,
    "range": 15,
    "objectIds": [
        "BURNING_BRAZIER_29314",
        "BURNING_BRAZIER_31926"
    ]
  },
```
https://github.com/Ben10164/RLHD/blob/9cb635344aa8b423caefeb6bef441d70684727f7/src/main/resources/rs117/hd/scene/lighting/lights.json#L29331-L29349


As well as moving the *Doors of Dihn* down to follow the Lit Brazier
```JSON
  {
    "description": "WINTERTODT_DOOR",
    "height": 500,
    "alignment": "SOUTH",
    "radius": 1500,
    "strength": 15,
    "color": [
        165,
        255,
        56
    ],
    "type": "STATIC",
    "duration": 0,
    "range": 0,
    "objectIds": [
        "DOORS_OF_DINH"
    ]
  }
```
https://github.com/Ben10164/RLHD/blob/9cb635344aa8b423caefeb6bef441d70684727f7/src/main/resources/rs117/hd/scene/lighting/lights.json#L29350-L29367

