### PR TITLE
East Ardy castle tile blending fix

### DIFF
--- a/src/main/java/rs117/hd/data/environments/Area.java
+++ b/src/main/java/rs117/hd/data/environments/Area.java
@@ -256,6 +256,12 @@ public enum Area
 		new Rect(2558, 3342, 2686, 3257),
 		new Rect(3328, 5887, 3392, 5951) // SOTE cutscene
 	),
+	EAST_ARDOUGNE_CASTLE_DIRT_FIX(
+		new Rect(2565, 3279, 2592, 3313)
+	),
+	EAST_ARDOUGNE_CASTLE_PATH_FIX(
+		new Rect(2585, 3298, 2593, 3314)
+	),
 
 	// Yanille
 	YANILLE_BANK(2609, 3088, 2616, 3097),

--- a/src/main/java/rs117/hd/data/materials/Overlay.java
+++ b/src/main/java/rs117/hd/data/materials/Overlay.java
@@ -130,6 +130,8 @@ public enum Overlay
 	CATHERBY_BANK_TILE_2(4, Area.CATHERBY_BANK, GroundMaterial.MARBLE_2_GLOSS, new Properties().setBlended(false)),
 
 	// Ardougne
+	EAST_ARDOUGNE_CASTLE_DIRT_FIX(14, Area.EAST_ARDOUGNE_CASTLE_DIRT_FIX, GroundMaterial.DIRT, new Properties().setShiftLightness(7).setBlended(false)),
+	EAST_ARDOUGNE_CASTLE_PATH_FIX(10, Area.EAST_ARDOUGNE_CASTLE_PATH_FIX, GroundMaterial.VARROCK_PATHS_LIGHT, new Properties().setShiftLightness(16).setBlended(false)),
 	EAST_ARDOUGNE_PATHS_1(10, Area.EAST_ARDOUGNE, GroundMaterial.VARROCK_PATHS_LIGHT, new Properties().setShiftLightness(6)),
 	WIZARD_HOUSE_TILE_LIGHT(38, Area.EAST_ARDOUGNE, GroundMaterial.MARBLE_1_SEMIGLOSS, new Properties().setBlended(false)),
 	WIZARD_HOUSE_TILE_DARK(40, Area.EAST_ARDOUGNE, GroundMaterial.MARBLE_2_SEMIGLOSS, new Properties().setBlended(false)),


### PR DESCRIPTION
Disables tile blending on some of the path leading to East Ardy's castle+bridge and all of the dirt immediately surrounding the castle to remove many tile blending artifacts. The area seems particularly vulnerable to them because of a lot of lumpy and sloped terrain with mixed tile types.

Also adjusted lightness to approx correct values so that things don't have seams or look unusual. They are area-based property adjustments so it's pretty easy to look over each affected tile, all looks good to me

![image](https://user-images.githubusercontent.com/73786759/171100571-df533aa9-b2f2-4824-977f-d1ec1d3d6f45.png)
![image](https://user-images.githubusercontent.com/73786759/171100579-a8a85fe1-7342-45ce-8ac3-f019f373ca13.png)
