### PR TITLE
Fix mistake in EnvironmentManager#updateSkyColor

### DIFF
--- a/src/main/java/rs117/hd/scene/EnvironmentManager.java
+++ b/src/main/java/rs117/hd/scene/EnvironmentManager.java
@@ -373,7 +373,7 @@ public class EnvironmentManager
 	public void updateSkyColor()
 	{
 		Environment env = hdPlugin.configWinterTheme ? Environment.WINTER : currentEnvironment;
-		if (!env.isCustomAmbientColor() || env.isAllowSkyOverride() && config.overrideSky())
+		if (!env.isCustomFogColor() || env.isAllowSkyOverride() && config.overrideSky())
 		{
 			DefaultSkyColor sky = config.defaultSkyColor();
 			targetFogColor = sky.getRgb(client);


### PR DESCRIPTION
Correct a bug introduced by #290. Thanks @xxEzri for pointing it out! This was accidentally changed to checking for a custom ambient color rather than fog color, which is what determines the color of the sky.