### PR TITLE
Light Crash Fixes

### DIFF
--- a/src/main/java/rs117/hd/scene/lighting/LightManager.java
+++ b/src/main/java/rs117/hd/scene/lighting/LightManager.java
@@ -358,7 +358,7 @@ public class LightManager
 
 			int tileX = (int) Math.floor(light.x / 128f);
 			int tileY = (int) Math.floor(light.y / 128f);
-			int tileZ = light.plane;
+			int tileZ = light.plane <= -1 ? 0 : light.plane;
 
 			light.belowFloor = false;
 			light.aboveFloor = false;

--- a/src/main/java/rs117/hd/scene/lighting/LightManager.java
+++ b/src/main/java/rs117/hd/scene/lighting/LightManager.java
@@ -225,6 +225,13 @@ public class LightManager
 
 			if (light.npc != null)
 			{
+
+				// prevent npcs at plane -1 and under from having lights
+				if (light.npc.getWorldLocation().getPlane() <= -1) {
+					lightIterator.remove();
+					continue;
+				}
+
 				if (light.npc != client.getCachedNPCs()[light.npc.getIndex()])
 				{
 					lightIterator.remove();
@@ -358,7 +365,7 @@ public class LightManager
 
 			int tileX = (int) Math.floor(light.x / 128f);
 			int tileY = (int) Math.floor(light.y / 128f);
-			int tileZ = light.plane <= -1 ? 0 : light.plane;
+			int tileZ = light.plane;
 
 			light.belowFloor = false;
 			light.aboveFloor = false;
@@ -639,6 +646,11 @@ public class LightManager
 	{
 		for (Light l : OBJECT_LIGHTS.get(tileObject.getId()))
 		{
+			// prevent objects at plane -1 and under from having lights
+			if (tileObject.getPlane() <= -1) {
+				continue;
+			}
+
 			// prevent duplicate lights being spawned for the same object
 			if (sceneLights.stream().anyMatch(light -> light.object != null && tileObjectHash(light.object) == tileObjectHash(tileObject)))
 			{


### PR DESCRIPTION
Teleporting to here Crashed the client

![image](https://user-images.githubusercontent.com/72366279/173398351-6f8ee0a6-eb93-41b1-aa3f-7249418fdc75.png)

![image](https://user-images.githubusercontent.com/72366279/173398453-c5b13955-a873-48ba-878d-12b5afaad8db.png)

As some light was showing the plane as -1, to fix this I made the change of if the TileZ is -1 or under it defaults to 0 to be safe, this is a bad crash as it happens in the wildy
